### PR TITLE
fix: Infinity loop when `Node_ID` equal `0`.

### DIFF
--- a/kafka/src/main/java/base/org/spin/eca56/util/queue/ApplicationDictionary.java
+++ b/kafka/src/main/java/base/org/spin/eca56/util/queue/ApplicationDictionary.java
@@ -64,6 +64,7 @@ public class ApplicationDictionary extends QueueManager implements IEngineDictio
 			queue.setProcessed(true);
 			queue.saveEx();
 		} catch (Throwable e) {
+			e.printStackTrace();
 			logger.warning(e.getLocalizedMessage());
 		}
 	}
@@ -92,6 +93,7 @@ public class ApplicationDictionary extends QueueManager implements IEngineDictio
 				if(documentByLanguage != null) {
 					sender.send(documentByLanguage, documentByLanguage.getChannel());
 				}
+				// TODO: Skip with `AD_Tree` and `AD_Role`
 				getLanguages().forEach(languageId -> {
 					MLanguage language = new MLanguage(getContext(), languageId, getTransactionName());
 					IGenericDictionaryDocument aloneDocument = getDocumentManager(entity, language.getAD_Language());


### PR DESCRIPTION
![imagen](https://github.com/user-attachments/assets/2660ecb7-607c-4959-81a9-20177bbbd0b1)

```sql
SELECT tn.Node_ID, tn.SeqNo FROM AD_TreeNodeMM tn
WHERE tn.AD_Tree_ID = 1000035 AND COALESCE(tn.Parent_ID, 0) = 0
```


```sql
SELECT tn.Node_ID, tn.SeqNo FROM AD_TreeNodeMM tn
WHERE tn.Node_ID > 0 AND tn.AD_Tree_ID = 1000035 AND COALESCE(tn.Parent_ID, 0) = 0
```

#### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/147