### PR TITLE
Bugfix Complete order with discount line

### DIFF
--- a/resources/0.5.8/10680_Column_M_AttributeSetInstance_ID_in_M_InOutLine_not_required.xml
+++ b/resources/0.5.8/10680_Column_M_AttributeSetInstance_ID_in_M_InOutLine_not_required.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Column M_AttributeSetInstance_ID in M_InOutLine not required" ReleaseNo="0.5.8" SeqNo="10680">
+    <Comments>Change column M_AttributeSetInstance_ID to be not required in table M_InOutLine</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="8772" Table="AD_Column">
+        <Data AD_Column_ID="124" Column="IsMandatory" oldValue="true">false</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">M_AttributeSetInstance_ID</Data>
+      </PO>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="20" StepType="SQL">
+      <SQLStatement>ALTER TABLE M_InOutLine ALTER COLUMN M_AttributeSetInstance_ID DROP NOT NULL;</SQLStatement>
+      <RollbackStatement>ALTER TABLE M_InOutLine ALTER COLUMN M_AttributeSetInstance_ID SET NOT NULL;</RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
makes the column M_AttributeSetInstance_ID not required in Dictionary and Database for table M_InOutLine. 

This way it won't cause Not Null Error when completing a Sales Order of type "Warehouse Order" or "POS Order" with discount lines.


https://github.com/user-attachments/assets/4384d032-3ea9-4005-9ba9-38bf301db619

### Addition context

Ref: https://github.com/solop-develop/adempiere-base/issues/84