### PR TITLE
If payment is Cash do not find PaymentProcessor

### DIFF
--- a/base/src/org/compiere/model/MPaymentProcessor.java
+++ b/base/src/org/compiere/model/MPaymentProcessor.java
@@ -66,6 +66,10 @@ public class MPaymentProcessor extends X_C_PaymentProcessor
 		int AD_Client_ID, int C_Currency_ID, BigDecimal Amt, String trxName)
 	{
 		ArrayList<MPaymentProcessor> list = new ArrayList<MPaymentProcessor>();
+
+		if (MPayment.TENDERTYPE_Cash.equals(tender)) {
+			return null;
+		}
 		StringBuffer sql = new StringBuffer("SELECT * "
 			+ "FROM C_PaymentProcessor "
 			+ "WHERE AD_Client_ID=? AND IsActive='Y'"				//	#1


### PR DESCRIPTION
### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/114