### PR TITLE
If GenerateSalesOrder process is multi selection  but only received record_id use the record_ID as selection

### DIFF
--- a/project/src/main/java/org/solop/project/process/GenerateSalesOrder.java
+++ b/project/src/main/java/org/solop/project/process/GenerateSalesOrder.java
@@ -69,7 +69,7 @@ public class GenerateSalesOrder extends GenerateSalesOrderAbstract {
 
 	private List<Integer> getProjectLineIds() {
 		if(isSelection()) {
-			return Optional.ofNullable(getSelectionKeys()).orElse(List.of());
+			return Optional.ofNullable(getSelectionKeys()).orElse(List.of(getRecord_ID()));
 		}
 		return List.of(getRecord_ID());
 	}


### PR DESCRIPTION
### Additional Context
Ref: