### PR TITLE
Update Order and Invoice Lines Project with ProjectLine project or header Project

### DIFF
--- a/base/src/org/compiere/model/MInvoice.java
+++ b/base/src/org/compiere/model/MInvoice.java
@@ -1064,6 +1064,15 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 			int no = DB.executeUpdate(sql, get_TrxName());
 			log.fine("Lines -> #" + no);
 		}
+		MInvoiceLine[] lines = getLines();
+		if (is_ValueChanged(MInvoice.COLUMNNAME_C_Project_ID)) {
+			for (MInvoiceLine line : lines) {
+				if (line.get_ValueAsInt("C_ProjectLine_ID") <= 0) {
+					line.setC_Project_ID(getC_Project_ID());
+				}
+				line.saveEx();
+			}
+		}
 		return true;
 	}	//	afterSave
 

--- a/base/src/org/compiere/model/MInvoiceLine.java
+++ b/base/src/org/compiere/model/MInvoiceLine.java
@@ -826,6 +826,23 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 		}
 		// Re-set invoice header (need to update m_IsSOTrx flag) - phib [ 1686773 ]
 		setInvoice(getParent());
+		//Project
+		if (getC_Project_ID() <= 0) {
+			if (get_ValueAsInt("C_ProjectLine_ID") > 0) {
+				MProjectLine projectLine = new MProjectLine(getCtx(), get_ValueAsInt("C_ProjectLine_ID"), get_TrxName());
+				setC_Project_ID(projectLine.getC_Project_ID());
+			} else if (m_parent.getC_Project_ID() > 0){
+				setC_Project_ID(m_parent.getC_Project_ID());
+			}
+		} else if (is_ValueChanged("C_ProjectLine_ID")) {
+			if(get_ValueAsInt("C_ProjectLine_ID") > 0) {
+				MProjectLine projectLine = new MProjectLine(getCtx(), get_ValueAsInt("C_ProjectLine_ID"), get_TrxName());
+				setC_Project_ID(projectLine.getC_Project_ID());
+			} else {
+				setC_Project_ID(0);
+			}
+		}
+
 		//	Charge
 		if (getC_Charge_ID() != 0)
 		{

--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -1126,7 +1126,8 @@ public class MOrder extends X_C_Order implements DocAction
 		    || is_ValueChanged(MOrder.COLUMNNAME_DatePromised)
 		    || is_ValueChanged(MOrder.COLUMNNAME_M_Warehouse_ID)
 		    || is_ValueChanged(MOrder.COLUMNNAME_M_Shipper_ID)
-		    || is_ValueChanged(MOrder.COLUMNNAME_C_Currency_ID)) {
+			|| is_ValueChanged(MOrder.COLUMNNAME_C_Currency_ID)
+		    || is_ValueChanged(MOrder.COLUMNNAME_C_Project_ID)) {
 			MOrderLine[] lines = getLines();
 			for (MOrderLine line : lines) {
 				if (is_ValueChanged("AD_Org_ID"))
@@ -1145,6 +1146,8 @@ public class MOrder extends X_C_Order implements DocAction
 					line.setM_Shipper_ID(getM_Shipper_ID());
 				if (is_ValueChanged(MOrder.COLUMNNAME_C_Currency_ID))
 					line.setC_Currency_ID(getC_Currency_ID());
+				if (is_ValueChanged(MOrder.COLUMNNAME_C_Project_ID) && line.get_ValueAsInt("C_ProjectLine_ID") <= 0)
+					line.setC_Project_ID(getC_Project_ID());
 				line.saveEx();
 			}
 		}

--- a/base/src/org/compiere/model/MOrderLine.java
+++ b/base/src/org/compiere/model/MOrderLine.java
@@ -881,7 +881,22 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 			setOrder (getParent());
 		if (m_M_PriceList_ID == 0)
 			setHeaderInfo(getParent());
-
+		//Project
+		if (getC_Project_ID() <= 0) {
+			if (get_ValueAsInt("C_ProjectLine_ID") > 0) {
+				MProjectLine projectLine = new MProjectLine(getCtx(), get_ValueAsInt("C_ProjectLine_ID"), get_TrxName());
+				setC_Project_ID(projectLine.getC_Project_ID());
+			} else if (m_parent.getC_Project_ID() > 0){
+				setC_Project_ID(m_parent.getC_Project_ID());
+			}
+		} else if (is_ValueChanged("C_ProjectLine_ID")) {
+			if(get_ValueAsInt("C_ProjectLine_ID") > 0) {
+				MProjectLine projectLine = new MProjectLine(getCtx(), get_ValueAsInt("C_ProjectLine_ID"), get_TrxName());
+				setC_Project_ID(projectLine.getC_Project_ID());
+			} else {
+				setC_Project_ID(0);
+			}
+		}
 		
 		//	R/O Check - Product/Warehouse Change
 		if (!newRecord 


### PR DESCRIPTION
If the document line has C_ProjectLine_ID but no C_Project_ID then sets the C_Project_ID from the Project Line, if not then sets it from the Header C_Project_ID.

Also when updating the header C_Project_ID then Updates the Lines C_Project_ID with the same ID only if the line does not have C_ProjectLine_ID.

### Video
https://www.loom.com/share/2bca521ebe4f4b79977786d7e8251539?sid=7fb82451-8993-4aaa-9853-4c95c4fb0362

### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/136