### PR TITLE
Obtain C_Project_ID only from line and not from Parent

### DIFF
--- a/base/src/org/compiere/model/MInvoiceLine.java
+++ b/base/src/org/compiere/model/MInvoiceLine.java
@@ -827,7 +827,7 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 		// Re-set invoice header (need to update m_IsSOTrx flag) - phib [ 1686773 ]
 		setInvoice(getParent());
 		//Project
-		if (getC_Project_ID() <= 0) {
+		if (get_ValueAsInt("C_Project_ID") <= 0) {
 			if (get_ValueAsInt("C_ProjectLine_ID") > 0) {
 				MProjectLine projectLine = new MProjectLine(getCtx(), get_ValueAsInt("C_ProjectLine_ID"), get_TrxName());
 				setC_Project_ID(projectLine.getC_Project_ID());


### PR DESCRIPTION
To validate if should update line C_Project_ID Before Save

### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/142