### PR TITLE
Add support in EntityTypeExport for exporting Report Views by EntityType

### DIFF
--- a/base/src/org/solop/util/EntityTypeExport.java
+++ b/base/src/org/solop/util/EntityTypeExport.java
@@ -34,6 +34,8 @@ public class EntityTypeExport extends GenericPOHandler {
 		createReferences(packOut, document, entityType.getEntityType(),  I_AD_Window.Table_Name, false, null);
 		//	Tables
 		createReferences(packOut, document, entityType.getEntityType(),  I_AD_Table.Table_Name, false, null);
+		//	Report Views
+		createReferences(packOut, document, entityType.getEntityType(),  I_AD_ReportView.Table_Name, false, null);
 		//	Validation Rules
 		createReferences(packOut, document, entityType.getEntityType(),  I_AD_Val_Rule.Table_Name, false, null);
 		//	Reference Header Only


### PR DESCRIPTION
When Exporting complete Entity, it takes into consideration the Report Views.

## Example Case
let's Create some data with a specific EntityType
### Original Data
 * Created an Entity `TEST`
 * Created a Report View with same EntityType
![imagen](https://github.com/user-attachments/assets/cba9b1f1-6960-4721-9637-b6b4626421f1)
 * Created a Report that uses the created Report View
![imagen](https://github.com/user-attachments/assets/4c746649-fc1b-44a1-a7ce-37931a1677a6)
 * Originally exporting the entity only exports the EntityType and the Process, not the Report View
![imagen](https://github.com/user-attachments/assets/bffb86b1-9576-4cfb-a00d-46948aa9a49d)
 * With the new change it exports the Report View first and the exports the Process
![imagen](https://github.com/user-attachments/assets/69a5387a-cf7e-40bf-b998-0f7c6fc43148)

### new Imported Data
* Imported the Package in a new DataBase
![imagen](https://github.com/user-attachments/assets/1ccb1785-3c9b-4f59-b220-1b4154ab24f4)
 * It Created the Report View
![imagen](https://github.com/user-attachments/assets/9d4d979f-e363-49db-a393-c8ef0b37204b)
 * And created the Process with the Report View
![imagen](https://github.com/user-attachments/assets/efa7b16b-9161-457b-a922-248a97ac4baa)




### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/152