### PR TITLE
Increase size of necessary columns for importing a package with a large AD_Rule Script

### DIFF
--- a/resources/0.7.6/10800_Increase_Packin_and_AD_Rule_column_size.xml
+++ b/resources/0.7.6/10800_Increase_Packin_and_AD_Rule_column_size.xml
@@ -21,7 +21,7 @@
         ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE TEXT USING ColValue::TEXT;
       </SQLStatement>
       <RollbackStatement>
-        ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE VARCHAR(2000) USING colvalue::VARCHAR(2000);
+        ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE VARCHAR(2000) USING ColValue::VARCHAR(2000);
       </RollbackStatement>
     </Step>
   </Migration>

--- a/resources/0.7.6/10800_Increase_Packin_and_AD_Rule_column_size.xml
+++ b/resources/0.7.6/10800_Increase_Packin_and_AD_Rule_column_size.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="10800_Increase_Packin_and_AD_Rule_column_size" ReleaseNo="" SeqNo="10800">
-    <Comments>Increase table AD_Package_Imp_Backup column ColValue and table AD_Rule column Script size to 160.000 to permit large scripts </Comments>
+  <Migration EntityType="D" Name="10800_Increase_Packin_and_AD_Rule_column_size" ReleaseNo="0.7.6" SeqNo="10800">
+    <Comments>Increase column ColValue in table AD_Package_Imp_Backup and column Script in table AD_Rule size to 160.000 to permit importing and saving large scripts </Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="50035" Table="AD_Column">
         <Data AD_Column_ID="118" Column="FieldLength" oldValue="2000">160000</Data>

--- a/resources/0.7.6/10800_Increase_Packin_and_AD_Rule_column_size.xml
+++ b/resources/0.7.6/10800_Increase_Packin_and_AD_Rule_column_size.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="10800_Increase_Packin_and_AD_Rule_column_size" ReleaseNo="" SeqNo="10800">
+    <Comments>Increase table AD_Package_Imp_Backup column ColValue and table AD_Rule column Script size to 160.000 to permit large scripts </Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="50035" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="2000">160000</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">ColValue</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="54257" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="8000">160000</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">Script</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step  DBType="Postgres" Parse="N" SeqNo="30" StepType="SQL">
+      <SQLStatement>
+        ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE varchar(160000) USING colvalue::varchar(160000);
+      </SQLStatement>
+      <RollbackStatement>
+        ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE varchar(2000) USING colvalue::varchar(2000);
+      </RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>

--- a/resources/0.7.6/10800_Increase_Packin_and_AD_Rule_column_size.xml
+++ b/resources/0.7.6/10800_Increase_Packin_and_AD_Rule_column_size.xml
@@ -18,10 +18,10 @@
     </Step>
     <Step  DBType="Postgres" Parse="N" SeqNo="30" StepType="SQL">
       <SQLStatement>
-        ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE varchar(160000) USING colvalue::varchar(160000);
+        ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE TEXT USING ColValue::TEXT;
       </SQLStatement>
       <RollbackStatement>
-        ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE varchar(2000) USING colvalue::varchar(2000);
+        ALTER TABLE AD_Package_Imp_Backup ALTER COLUMN ColValue TYPE VARCHAR(2000) USING colvalue::VARCHAR(2000);
       </RollbackStatement>
     </Step>
   </Migration>


### PR DESCRIPTION
Increases the following Columns size to 160.000:
 - `ColValue` in `AD_Package_Imp_Backup`
 - `Script` in `AD_Rule`

### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/155