### PR TITLE
Keeps original OrderLineID in InvoiceLine when created from process CreateFrom

### DIFF
--- a/base/src/org/compiere/process/InvoiceCreateFrom.java
+++ b/base/src/org/compiere/process/InvoiceCreateFrom.java
@@ -112,7 +112,6 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 				invoiceLine.setC_Invoice_ID(invoiceLine.getParent().getC_Invoice_ID());
 				invoiceLine.setAD_Org_ID(fromLine.getAD_Org_ID());
 				//	Reset
-				invoiceLine.setC_OrderLine_ID(0);
 				invoiceLine.setRef_InvoiceLine_ID(0);
 				invoiceLine.setM_InOutLine_ID(0);
 				invoiceLine.setA_Asset_ID(0);


### PR DESCRIPTION
### Video
https://www.loom.com/share/92302b830a1b4320aa6f8bab7d2f9495?sid=6a297f68-7902-4538-9c77-e7aa4a925f3b

### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/162