### PR TITLE
Sets Reference Document In Header and validates partial qty

### DIFF
--- a/base/src/org/compiere/model/MInvoice.java
+++ b/base/src/org/compiere/model/MInvoice.java
@@ -2016,20 +2016,35 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 		if(documentType.get_ValueAsBoolean("IsAutomaticAllocation")) {
 			AllocationManager allocationManager = new AllocationManager(this);
 			int invoiceToAllocateId = get_ValueAsInt("ReferenceDocument_ID");
+			MTable allocateInvoiceTable = MTable.get(getCtx(), "C_AllocateInvoice");
+			String whereClause = "C_Invoice_ID = ?";
+			if (invoiceToAllocateId <= 0) {
+				if (allocateInvoiceTable != null && allocateInvoiceTable.get_ID() > 0) {
+					String getAllocateInvoicesCountSql = "SELECT COUNT(DISTINCT(ReferenceDocument_ID)) FROM C_AllocateInvoice WHERE C_Invoice_ID = ?";
+					int allocateInvoicesCount = DB.getSQLValue(get_TrxName(), getAllocateInvoicesCountSql, get_ID());
+					if (allocateInvoicesCount == 1) {
+						int allocateInvoiceId = new Query(getCtx(), allocateInvoiceTable.getTableName(),whereClause, get_TrxName())
+								.setParameters(get_ID())
+								.firstId();
+						PO AllocateInvoice = allocateInvoiceTable.getPO(allocateInvoiceId,get_TrxName());
+						invoiceToAllocateId = AllocateInvoice.get_ValueAsInt("ReferenceDocument_ID");
+						set_ValueOfColumn("ReferenceDocument_ID", invoiceToAllocateId);
+					}
+				}
+			}
 			if (invoiceToAllocateId > 0) {
 				allocationManager.addAllocateDocument(invoiceToAllocateId, getGrandTotal(), Env.ZERO, Env.ZERO);
 				allocationManager.createAllocation();
 			} else {
-				MTable allocateInvoiceTable = MTable.get(getCtx(), "C_AllocateInvoice");
+
 				if (allocateInvoiceTable != null && allocateInvoiceTable.getAD_Table_ID() > 0) {
-					String whereClause = "C_Invoice_ID = ?";
 					List<Integer> allocateInvoiceIds = new Query(getCtx(), allocateInvoiceTable.getTableName(),whereClause, get_TrxName())
 						.setParameters(get_ID())
-							.getIDsAsList();
+						.getIDsAsList();
 					HashMap<Integer, BigDecimal> currencyConvertRate = new HashMap<>();
 					allocateInvoiceIds.forEach(allocationId -> {
 						PO allocation = allocateInvoiceTable.getPO(allocationId, get_TrxName());
-						BigDecimal amountToAllocate = Optional.ofNullable((BigDecimal) get_Value("AllocateAmount"))
+						BigDecimal amountToAllocate = Optional.ofNullable((BigDecimal) allocation.get_Value("AllocateAmount"))
 							.orElse(Env.ZERO);
 						if (amountToAllocate.signum() == 0) {
 							MInvoice referenceInvoice = MInvoice.get(getCtx(), allocation.get_ValueAsInt("ReferenceDocument_ID"));
@@ -2665,7 +2680,7 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 		if(cash != null) {
 			return cash.getC_CashBook_ID();
 		}
-		//	
+		//
 		return -1;
 	}
 
@@ -2686,7 +2701,7 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 		if(cashAccountId <= 0) {
 			throw new AdempiereException("@NoCashBook@");
 		}
-		//	
+		//
 		MPayment paymentCash = new MPayment(getCtx(), 0, get_TrxName());
 		paymentCash.setC_BankAccount_ID(cashAccountId);
 		paymentCash.setC_DocType_ID(true);

--- a/base/src/org/compiere/process/InvoiceCreateFrom.java
+++ b/base/src/org/compiere/process/InvoiceCreateFrom.java
@@ -148,8 +148,6 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 			}
 			invoiceLine.setQty(qtyEntered);							//	Movement/Entered
 			invoiceLine.setQtyInvoiced(qtyInvoiced);
-			invoiceLine.setLineNetAmt();
-			invoiceLine.setTaxAmt();
 			//	Save
 			invoiceLine.saveEx();
 			if(createFromType.equals(INVOICE)) {

--- a/base/src/org/compiere/process/InvoiceCreateFrom.java
+++ b/base/src/org/compiere/process/InvoiceCreateFrom.java
@@ -17,7 +17,19 @@
 package org.compiere.process;
 
 import org.adempiere.exceptions.AdempiereException;
-import org.compiere.model.*;
+import org.compiere.model.MInOut;
+import org.compiere.model.MInOutLine;
+import org.compiere.model.MInvoice;
+import org.compiere.model.MInvoiceLine;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MProduct;
+import org.compiere.model.MRMA;
+import org.compiere.model.MRMALine;
+import org.compiere.model.MTable;
+import org.compiere.model.MTax;
+import org.compiere.model.MUOMConversion;
+import org.compiere.model.PO;
 import org.compiere.util.Env;
 
 import java.math.BigDecimal;
@@ -122,6 +134,26 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 					invoiceLine.setTax();	//	recalculate
 				//
 				invoiceLine.setProcessed(false);
+			} else if(createFromType.equals(RMA)) {
+				MRMALine rmaLine = new MRMALine(getCtx(), key, get_TrxName());
+				//	Set reference
+				referenceId.set(rmaLine.getM_RMA_ID());
+				//
+				invoiceLine.setRMALine(rmaLine);
+			} else if(createFromType.equals(RECEIPT)) {
+				MInOutLine inOutLine = new MInOutLine(getCtx(), key, get_TrxName());
+				//	Set reference
+				referenceId.set(inOutLine.getM_InOut_ID());
+				invoiceLine.setShipLine(inOutLine);
+			}
+			invoiceLine.setQty(qtyEntered);							//	Movement/Entered
+			invoiceLine.setQtyInvoiced(qtyInvoiced);
+			invoiceLine.setLineNetAmt();
+			invoiceLine.setTaxAmt();
+			//	Save
+			invoiceLine.saveEx();
+			if(createFromType.equals(INVOICE)) {
+				MInvoiceLine fromLine = new MInvoiceLine(getCtx(), key, get_TrxName());
 				//Automatic Allocation
 				MTable allocateInvoiceTable = MTable.get(getCtx(), "C_AllocateInvoice");
 				if (allocateInvoiceTable != null && allocateInvoiceTable.getAD_Table_ID() > 0) {
@@ -137,24 +169,6 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 					allocateInvoice.set_ValueOfColumn("AllocateAmount", maybeAllocateAmount.get());
 					allocateInvoice.saveEx();
 				}
-			} else if(createFromType.equals(RMA)) {
-				MRMALine rmaLine = new MRMALine(getCtx(), key, get_TrxName());
-				//	Set reference
-				referenceId.set(rmaLine.getM_RMA_ID());
-				//
-				invoiceLine.setRMALine(rmaLine);
-			} else if(createFromType.equals(RECEIPT)) {
-				MInOutLine inOutLine = new MInOutLine(getCtx(), key, get_TrxName());
-				//	Set reference
-				referenceId.set(inOutLine.getM_InOut_ID());
-				invoiceLine.setShipLine(inOutLine);
-			}
-			invoiceLine.setQty(qtyEntered);							//	Movement/Entered
-			invoiceLine.setQtyInvoiced(qtyInvoiced);
-			//	Save
-			invoiceLine.saveEx();
-			if(createFromType.equals(INVOICE)) {
-				MInvoiceLine fromLine = new MInvoiceLine(getCtx(), key, get_TrxName());
 				// MZ Goodwill
 				// copy the landed cost
 				invoiceLine.copyLandedCostFrom(fromLine);


### PR DESCRIPTION
 - Automatic invoice Allocation Records are created AFTER the calculations of the line
 - if the Allocate Invoice Lines reference just One invoice, sets that invoice ID in the "Reference Document" column in the Header
### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/174