### PR TITLE
Fixes Display Logic of  "Copy Document No On Reverse" Field

### DIFF
--- a/resources/0.7.11/10850_Fix_DisplayLogic_for_Copy_Document_No_On_Reversal.xml
+++ b/resources/0.7.11/10850_Fix_DisplayLogic_for_Copy_Document_No_On_Reversal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="U" Name="10850_Fix_DisplayLogic_for_Copy_Document_No_On_Reversal" ReleaseNo="" SeqNo="10850">
+  <Migration EntityType="D" Name="10850_Fix_DisplayLogic_for_Copy_Document_No_On_Reversal" ReleaseNo="" SeqNo="10850">
     <Comments>DisplayLogic was not getting correctly context information</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="107" Action="U" Record_ID="82920" Table="AD_Field">

--- a/resources/0.7.11/10850_Fix_DisplayLogic_for_Copy_Document_No_On_Reversal.xml
+++ b/resources/0.7.11/10850_Fix_DisplayLogic_for_Copy_Document_No_On_Reversal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="U" Name="10850_Fix_DisplayLogic_for_Copy_Document_No_On_Reversal" ReleaseNo="" SeqNo="10850">
+    <Comments>DisplayLogic was not getting correctly context information</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="82920" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" oldValue="DocBaseType='MMI' | DocBaseType='MMM' | DocBaseType='MMR' | DocBaseType='MMS' | DocBaseType='MMP' | DocBaseType='API' | DocBaseType='APC' | DocBaseType='ARI' | DocBaseType='ARC' | DocBaseType='ARR' | DocBaseType='APP' | DocBaseType='GLJ' | DocBaseType='PRJ' | DocBaseType='RRJ'  | DocBaseType='DRI'">@DocBaseType@='MMI' | @DocBaseType@='MMM' | @DocBaseType@='MMR' | @DocBaseType@='MMS' | @DocBaseType@='MMP' | @DocBaseType@='API' | @DocBaseType@='APC' | @DocBaseType@='ARI' | @DocBaseType@='ARC' | @DocBaseType@='ARR' | @DocBaseType@='APP' | @DocBaseType@='GLJ' | @DocBaseType@='PRJ' | @DocBaseType@='RRJ'  | @DocBaseType@='DRI'</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Change display logic for  "Copy Document No On Reverse" Field in Document Type Window to use the "@" Correctly to get the context information
### Image
![imagen](https://github.com/user-attachments/assets/25e5ca6e-9f9d-4d4a-b37b-ea68f4719a81)

### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/186