### PR TITLE
Increase SqlStatement Column Length in Package Export Detail

### DIFF
--- a/resources/0.8.8/11100_SqlStatement_Length_in_Package_Export_Detail.xml
+++ b/resources/0.8.8/11100_SqlStatement_Length_in_Package_Export_Detail.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="11100_SqlStatement_Length_in_Package_Export_Detail" ReleaseNo="0.8.8" SeqNo="11100">
+    <Comments>Change SqlStatement column length to 80000 in Package_Export_Detail</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="50122" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="2000">80000</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">SQLStatement</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step DBType="Postgres" Parse="Y" SeqNo="20" StepType="SQL">
+      <SQLStatement>
+        ALTER TABLE AD_Package_Exp_Detail ALTER COLUMN SqlStatement TYPE TEXT USING SqlStatement::TEXT;
+      </SQLStatement>
+      <RollbackStatement>
+        ALTER TABLE AD_Package_Exp_Detail ALTER COLUMN SqlStatement TYPE VARCHAR(2000) USING SqlStatement::VARCHAR(2000);
+      </RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Increase from 2000 to 80,000 in Dictionary and Change DB type to TEXT
### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/264