### PR TITLE
Set C_ProjectLine_ID in InvoiceLine from OrderLine

### DIFF
--- a/base/src/org/compiere/model/MInvoiceLine.java
+++ b/base/src/org/compiere/model/MInvoiceLine.java
@@ -219,6 +219,7 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 		setLineNetAmt(oLine.getLineNetAmt());
 		//
 		setC_Project_ID(oLine.getC_Project_ID());
+		set_ValueOfColumn("C_ProjectLine_ID", oLine.get_ValueAsInt("C_ProjectLine_ID"));
 		setC_ProjectPhase_ID(oLine.getC_ProjectPhase_ID());
 		setC_ProjectTask_ID(oLine.getC_ProjectTask_ID());
 		setC_Activity_ID(oLine.getC_Activity_ID());


### PR DESCRIPTION
When setting OrderLine to a InvoiceLine set the C_ProjectLine_ID from the OrderLine

### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/285