### PR TITLE
No POS in Cash Withdrawal

### DIFF
--- a/base/src/main/java/org/spin/cash/util/CashManagementUtil.java
+++ b/base/src/main/java/org/spin/cash/util/CashManagementUtil.java
@@ -119,6 +119,7 @@ public class CashManagementUtil {
 		if(paymentId > 0) {
 			MPayment originalPayment = new MPayment(bankStatement.getCtx(), paymentId, bankStatement.get_TrxName());
 			PO.copyValues(originalPayment, paymentBankFrom);
+			paymentBankFrom.setC_POS_ID(-1);
 		}
 		paymentBankFrom.setRelatedPayment_ID(-1);
 		paymentBankFrom.setC_BankAccount_ID(mBankFrom.getC_BankAccount_ID());
@@ -147,6 +148,7 @@ public class CashManagementUtil {
 		//
 		MPayment paymentBankTo = new MPayment(bankStatement.getCtx(), 0 ,  bankStatement.get_TrxName());
 		PO.copyValues(paymentBankFrom, paymentBankTo);
+		paymentBankTo.setC_POS_ID(-1);
 		paymentBankTo.setC_BankAccount_ID(mBankTo.getC_BankAccount_ID());
 		paymentBankTo.setDocumentNo(documentNo);
 		paymentBankTo.setDateAcct(dateAcct);


### PR DESCRIPTION
when creating the withdrawal documents do not copy the C_POS_ID, this way the report has an easy way to determine what movements should not be used
### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/341