### PR TITLE
fix: `ValueManager.getTimestampFromDate` method.

### DIFF
--- a/grpc_utils/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
+++ b/grpc_utils/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
@@ -462,6 +462,16 @@ public class ValueManager {
 	public static Timestamp getTimestampFromProtoTimestamp(com.google.protobuf.Timestamp dateValue) {
 		return TimeManager.getTimestampFromProtoTimestamp(dateValue);
 	}
+	/**
+	 * Get google.protobuf.Timestamp from Timestamp
+	 * @deprecated Use {@link TimeManager#getProtoTimestampFromTimestamp(Timestamp)} instead.
+	 * @param dateValue
+	 * @return com.google.protobuf.Timestamp
+	 */
+	@Deprecated
+	public static com.google.protobuf.Timestamp getTimestampFromDate(Timestamp dateValue) {
+		return TimeManager.getProtoTimestampFromTimestamp(dateValue);
+	}
 
 
 	/**

--- a/grpc_utils/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
+++ b/grpc_utils/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
@@ -446,10 +446,12 @@ public class ValueManager {
 		return TimeManager.getProtoTimestampFromTimestamp(value);
 	}
 	/**
+	 * @deprecated Use {@link TimeManager#getProtoTimestampFromTimestamp(Value)} instead.
 	 * Get google.protobuf.Timestamp from Timestamp
 	 * @param dateValue
 	 * @return com.google.protobuf.Timestamp
 	 */
+	@Deprecated
 	public static com.google.protobuf.Timestamp getProtoTimestampFromTimestamp(Timestamp dateValue) {
 		return TimeManager.getProtoTimestampFromTimestamp(dateValue);
 	}


### PR DESCRIPTION
```
 4 actionable tasks: 4 executed
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler output below.
  Note: Recompile with -Xlint:deprecation for details.
  Note: Some input files use or override a deprecated API.
  /home/runner/work/adempiere-processors-service/adempiere-processors-service/src/main/java/org/spin/processor/service/Service.java:47: error: cannot find symbol
  				ValueManager.getTimestampFromDate(
  				            ^
    symbol:   method getTimestampFromDate(Timestamp)
    location: class ValueManager
  1 error
  ```