### PR TITLE
When importing Many XMLs order them by AbsolutePath

### DIFF
--- a/base/src/main/java/org/compiere/process/MigrationFromXML.java
+++ b/base/src/main/java/org/compiere/process/MigrationFromXML.java
@@ -82,7 +82,7 @@ public class MigrationFromXML extends MigrationFromXMLAbstract {
 	public Comparator<File> fileComparator = new Comparator<File>() {
 		// Note - Not locale sensitive.
 	    public int compare(File f1, File f2) {
-	        return f1.getName().compareToIgnoreCase(f2.getName());
+	        return f1.getAbsolutePath().compareToIgnoreCase(f2.getAbsolutePath());
 	    }
 	};
 		

--- a/base/src/main/java/org/solop/migration/util/ProtoMigration.java
+++ b/base/src/main/java/org/solop/migration/util/ProtoMigration.java
@@ -116,7 +116,7 @@ public class ProtoMigration implements IMigrationManagement {
 			try {
 				int migrationId = loadFile(file, finder);
 				if(migrationId > 0) {
-					migrationsToApply.put(file.getName(), migrationId);
+					migrationsToApply.put(file.getAbsolutePath(), migrationId);
 				}
 			} catch (Exception e) {
 				log.log(Level.SEVERE, e.getLocalizedMessage());

--- a/base/src/main/java/org/solop/migration/util/XMLMigration.java
+++ b/base/src/main/java/org/solop/migration/util/XMLMigration.java
@@ -96,7 +96,7 @@ public class XMLMigration implements IMigrationManagement {
 			try {
 				int migrationId = loadFile(file, finder);
 				if(migrationId > 0) {
-					migrationsToApply.put(file.getName(), migrationId);
+					migrationsToApply.put(file.getAbsolutePath(), migrationId);
 				}
 			} catch (Exception e) {
 				log.log(Level.SEVERE, e.getLocalizedMessage());


### PR DESCRIPTION
This allows to import first the core XMLs then the other projects XMLs
### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/497