### PR TITLE
Remove DateAcct Callout from Documents

### DIFF
--- a/resources/1.5.2/00501940_D_1_5_2_Remove_DateAcct_Callout.xml
+++ b/resources/1.5.2/00501940_D_1_5_2_Remove_DateAcct_Callout.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Remove_DateAcct_Callout" ReleaseNo="1.5.2" SeqNo="501940">
+    <Comments>Remove DateAcct Callout from documentDate Columns in Invoice, Payment, Order, InOut Journal and Journal batch</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="3783" Table="AD_Column">
+        <Data AD_Column_ID="1692" Column="Callout" oldValue="org.compiere.model.CalloutEngine.dateAcct; org.compiere.model.CalloutOrder.priceList">org.compiere.model.CalloutOrder.priceList</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="2181" Table="AD_Column">
+        <Data AD_Column_ID="1692" Column="Callout" oldValue="org.compiere.model.CalloutEngine.dateAcct; org.compiere.model.CalloutOrder.priceList">org.compiere.model.CalloutOrder.priceList</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="5399" Table="AD_Column">
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true" oldValue="org.compiere.model.CalloutEngine.dateAcct"/>
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="0">7</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">DateTrx</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="3517" Table="AD_Column">
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true" oldValue="org.compiere.model.CalloutEngine.dateAcct"/>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="1634" Table="AD_Column">
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true" oldValue="org.compiere.model.CalloutEngine.dateAcct"/>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="1793" Table="AD_Column">
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true" oldValue="org.compiere.model.CalloutEngine.dateAcct"/>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
it is now controlled by their Model Class
### Additional Context
Fixes: https://github.com/solop-develop/adempiere-base/issues/550