### PR TITLE
Fix duplicate `AD_PInstance_Log_ID` in GenerateSurrogateKeys parallel run

### DIFF
--- a/base/src/main/java/org/eevolution/process/GenerateSurrogateKeys.java
+++ b/base/src/main/java/org/eevolution/process/GenerateSurrogateKeys.java
@@ -21,12 +21,17 @@ import org.compiere.model.MColumn;
 import org.compiere.model.MTable;
 import org.compiere.model.M_Element;
 import org.compiere.model.Query;
-import org.compiere.util.*;
+import org.compiere.util.DB;
+import org.compiere.util.DisplayType;
+import org.compiere.util.Env;
+import org.compiere.util.Trx;
+import org.compiere.util.TrxRunnable;
 import org.jfree.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /** Generated Process for (Generate Surrogate Key UUID for all tables)
@@ -46,14 +51,24 @@ public class GenerateSurrogateKeys extends GenerateSurrogateKeysAbstract
 	{
 		List<Integer> tableList = getTableList(get_TrxName());
 		//	Add columns
-		tableList.stream().filter(Objects::nonNull).forEach(this::addColumn);
+		tableList.stream()
+			.filter(Objects::nonNull)
+			.forEach(this::addColumn)
+		;
 		//	Generate Surrogate Keys
 		if (isGenerateUUIDforallrecords()) {
+			// Collect log messages from parallel workers in a thread-safe queue.
+			// addLog() mutates ProcessInfo.logs (a non-thread-safe ArrayList);
+			// calling it from parallelStream corrupts the list and later causes
+			// duplicate AD_PInstance_Log_ID inserts in ProcessInfoUtil.saveLogToDB.
+			ConcurrentLinkedQueue<String> logMessages = new ConcurrentLinkedQueue<>();
 			tableList.parallelStream().filter(Objects::nonNull).forEach(tableId -> {
 				Trx.run(transactionName -> {
-					generateUUIDByTable(tableId, transactionName);
+					generateUUIDByTable(tableId, transactionName, logMessages);
 				});
 			});
+			// Flush collected messages sequentially from the main thread.
+			logMessages.forEach(this::addLog);
 		}
 		return "@Ok@";
 	}
@@ -125,13 +140,13 @@ public class GenerateSurrogateKeys extends GenerateSurrogateKeysAbstract
 		}
 	}
 
-	private void generateUUIDByTable(int tableId, String transactionName) {
+	private void generateUUIDByTable(int tableId, String transactionName, ConcurrentLinkedQueue<String> logMessages) {
 		String tableName = MTable.getTableName(getCtx(), tableId);
 		try {
 			int updated = DB.executeUpdateEx("UPDATE " + tableName + " SET UUID = getUUID() WHERE UUID IS NULL", transactionName);
-			addLog(tableName + " @Updated@: " + updated);
+			logMessages.add(tableName + " @Updated@: " + updated);
 		} catch (Exception e) {
-			addLog(tableName + " @Error@: " + e.getLocalizedMessage());
+			logMessages.add(tableName + " @Error@: " + e.getLocalizedMessage());
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix `duplicate key value violates unique constraint "ad_pinstance_log_pkey"` thrown by `GenerateSurrogateKeys` when running the migration loader.

### Root cause

`doIt()` iterated `tableList.parallelStream()` and called `addLog(...)` from each worker thread. `ProcessInfo.logs` is a plain `ArrayList`, so concurrent mutations corrupted its internal state. When `SvrProcess.unlock()` later flushed the logs via `ProcessInfoUtil.saveLogToDB`, the `AD_PInstance_Log_ID` sequence collided and Postgres rejected the insert:

### Changes

- `GenerateSurrogateKeys.java`
  - Keep the parallel `UPDATE ... SET UUID = getUUID()` execution (that's where the speedup is).
  - Collect per-table log messages into a `ConcurrentLinkedQueue<String>` inside the parallel block instead of touching `ProcessInfo.logs`.
  - Flush the queue sequentially via `addLog(...)` from the main thread once the parallel work completes.

### Additional context

```
12:56:10.917 GenerateSurrogateKeys.addLog: 0 - null - null - AD_PrintForm @Updated@: 0 [18]
12:56:10.920 GenerateSurrogateKeys.addLog: 0 - null - null - AD_PrintFormat @Updated@: 0 [18]
===========> DB.executeUpdate: INSERT INTO AD_PInstance_Log (AD_PInstance_ID, AD_PInstance_Log_ID, P_Date, P_ID, P_Number, P_Msg) VALUES (4804421,653,NULL,NULL,NULL,'C_BankStatementLoader @Updated@: 0') [null] [1]
org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "ad_pinstance_log_pkey"
  Detail: Key (ad_pinstance_id, ad_pinstance_log_id)=(4804421, 653) already exists.; State=23505; ErrorCode=0
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:134)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
	at jdk.internal.reflect.GeneratedMethodAccessor5.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
	at jdk.proxy3/jdk.proxy3.$Proxy3.executeUpdate(Unknown Source)
	at org.compiere.util.DB.executeUpdate(DB.java:1006)
	at org.compiere.util.DB.executeUpdate(DB.java:868)
	at org.compiere.util.DB.executeUpdate(DB.java:855)
	at org.compiere.process.ProcessInfoUtil.saveLogToDB(ProcessInfoUtil.java:190)
	at org.compiere.process.SvrProcess.unlock(SvrProcess.java:855)
	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:152)
	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:176)

===========> GenerateSurrogateKeys.unlock: unlock() - org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "ad_pinstance_log_pkey"
  Detail: Key (ad_pinstance_id, ad_pinstance_log_id)=(4804421, 653) already exists. [1]
```