### PR TITLE
fix: NPE when execute Financial Report

### DIFF
--- a/base/src/main/java/org/compiere/report/FinReport.java
+++ b/base/src/main/java/org/compiere/report/FinReport.java
@@ -98,6 +98,9 @@ public class FinReport extends FinReportAbstract {
         setPeriods();
         financialReportInfo.append(" - C_Period_ID=").append(getPeriodId()).append(" - ").append(parameterWhere);
         ProcessInfoParameter[] pi = getProcessInfo().getParameter();
+        if (pi == null || pi.length == 0) {
+            throw new AdempiereUserError("@No@ @AD_Process_Para_ID@");
+        }
         pi[0].setParameter(getPeriodId());
         getProcessInfo().setParameter(pi);
         log.info(financialReportInfo.toString());

--- a/base/src/main/java/org/compiere/report/FinReport.java
+++ b/base/src/main/java/org/compiere/report/FinReport.java
@@ -99,7 +99,12 @@ public class FinReport extends FinReportAbstract {
         financialReportInfo.append(" - C_Period_ID=").append(getPeriodId()).append(" - ").append(parameterWhere);
         ProcessInfoParameter[] pi = getProcessInfo().getParameter();
         if (pi == null || pi.length == 0) {
-            throw new AdempiereUserError("@No@ @AD_Process_Para_ID@");
+            throw new RuntimeException(
+                Msg.parseTranslation(
+                    getCtx(),
+                    "@No@ @AD_Process_Para_ID@"
+                )
+            );
         }
         pi[0].setParameter(getPeriodId());
         getProcessInfo().setParameter(pi);

--- a/base/src/main/java/org/compiere/report/FinReport.java
+++ b/base/src/main/java/org/compiere/report/FinReport.java
@@ -117,11 +117,13 @@ public class FinReport extends FinReportAbstract {
         log.fine("Report Lines = " + no);
         //	** Get Data	** Segment Values
         reportColumns = finReport.getColumnSet().getColumns();
-        if (reportColumns.length == 0)
+        if (reportColumns == null || reportColumns.length == 0) {
             throw new AdempiereUserError("@No@ @PA_ReportColumn_ID@");
+        }
         reportLines = finReport.getLineSet().getLines();
-        if (reportLines.length == 0)
+        if (reportLines == null || reportLines.length == 0) {
             throw new AdempiereUserError("@No@ @PA_ReportLine_ID@");
+        }
 
         //	for all lines
         for (MReportLine reportLine : reportLines) {
@@ -985,8 +987,10 @@ public class FinReport extends FinReportAbstract {
      */
     private void insertLineSource(MReportLine reportLine) {
         //	No source lines
-        if (reportLine == null || reportLine.getSources().length == 0)
+        if (reportLine == null || reportLine.getSources() == null || reportLine.getSources().length == 0) {
+            log.warning("No Source lines: " + reportLine);
             return;
+        }
         //	Log
         log.info("Line=" + reportLine.getSeqNo() + " - " + reportLine);
         //
@@ -1192,7 +1196,7 @@ public class FinReport extends FinReportAbstract {
             //	Set Name,Description
             StringBuilder updateNameAndDesc = new StringBuilder("UPDATE T_Report SET (Name,Description)=(");
             String sourceValueQuery = reportLine.getSourceValueQuery();
-            if (sourceValueQuery.length() == 0 && isCombination) {
+            if ((sourceValueQuery == null || sourceValueQuery.length() == 0) && isCombination) {
                 updateNameAndDesc.append("SELECT Combination , Description FROM C_ValidCombination WHERE C_ValidCombination_ID=").append(combinationId);
             } else {
                 updateNameAndDesc.append(sourceValueQuery);


### PR DESCRIPTION
* When report columns is null.
* when report lines is null.
* When report line sources is null.


### Additional context
```
===========> FinReport.process: Index 0 out of bounds for length 0 [39]
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.compiere.report.FinReport.prepare(FinReport.java:101)
	at org.compiere.process.SvrProcess.process(SvrProcess.java:176)
	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:130)
	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:176)
	at org.spin.report_engine.service.ReportProcessor.startProcess(ReportProcessor.java:213)
	at org.spin.report_engine.service.ReportProcessor.run(ReportProcessor.java:131)
	at org.spin.report_engine.service.ReportBuilder.lambda$run$7(ReportBuilder.java:316)
	at org.compiere.util.Trx.run(Trx.java:529)
	at org.compiere.util.Trx.run(Trx.java:497)
	at org.spin.report_engine.service.ReportBuilder.run(ReportBuilder.java:310)
	at org.spin.report_engine.service.Service.getExportReport(Service.java:331)
	at org.spin.report_engine.controller.ReportService.runExport(ReportService.java:96)
	at org.spin.backend.grpc.report_engine.ReportEngineGrpc$MethodHandlers.invoke(ReportEngineGrpc.java:450)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
	at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
```


```
===========> FinReport.process: Cannot read the array length because "this.reportColumns" is null [38]
java.lang.NullPointerException: Cannot read the array length because "this.reportColumns" is null
	at org.compiere.report.FinReport.doIt(FinReport.java:120)
	at org.compiere.process.SvrProcess.process(SvrProcess.java:177)
	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:130)
	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:176)
	at org.spin.report_engine.service.ReportProcessor.startProcess(ReportProcessor.java:213)
	at org.spin.report_engine.service.ReportProcessor.run(ReportProcessor.java:131)
	at org.spin.report_engine.service.ReportBuilder.lambda$run$7(ReportBuilder.java:316)
	at org.compiere.util.Trx.run(Trx.java:529)
	at org.compiere.util.Trx.run(Trx.java:497)
	at org.spin.report_engine.service.ReportBuilder.run(ReportBuilder.java:310)
	at org.spin.report_engine.service.Service.getExportReport(Service.java:331)
	at org.spin.report_engine.controller.ReportService.runExport(ReportService.java:96)
	at org.spin.backend.grpc.report_engine.ReportEngineGrpc$MethodHandlers.invoke(ReportEngineGrpc.java:450)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
	at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
```