### PR TITLE
fix: Keep MSession/MRole cache in sync within each JVM

### DIFF
--- a/base/src/main/java/org/compiere/model/MRole.java
+++ b/base/src/main/java/org/compiere/model/MRole.java
@@ -207,6 +207,20 @@ public final class MRole extends X_AD_Role
 		
 	/** Role/User Cache			*/
 	private static CCache<String,MRole> s_roles = new CCache<String,MRole>("AD_Role", 5);
+
+	/**
+	 * Evict cached MRole entry for the given (role, user) pair so the next
+	 * {@link #get(Properties, int, int, boolean)} reloads from DB and rebuilds
+	 * access SQL. Call this after operations that change the user's effective
+	 * tenant or org access (e.g. change-role).
+	 */
+	public static void removeFromCache(int roleId, int userId)
+	{
+		if (roleId < 0 || userId < 0) {
+			return;
+		}
+		s_roles.remove(roleId + "_" + userId);
+	}
 	/** Log						*/ 
 	private static CLogger			s_log = CLogger.getCLogger(MRole.class);
 	

--- a/base/src/main/java/org/compiere/model/MSession.java
+++ b/base/src/main/java/org/compiere/model/MSession.java
@@ -254,13 +254,30 @@ public class MSession extends X_AD_Session
 	}	//	toString
 
 	/**
+	 * Keep the local cache in sync with the row's current state on every save.
+	 * Any caller in this JVM that later does {@link #get(Properties, boolean, boolean)}
+	 * sees up-to-date column values (including {@code Processed}) without an
+	 * extra DB hit. We deliberately keep processed sessions cached so callers
+	 * that need them (audit/changelog, keepalive on closing sessions) still get
+	 * the row — it is the caller's responsibility to check {@code isProcessed()}.
+	 * Cross-JVM invalidation still requires the distributed cache (pending as Redis).
+	 */
+	@Override
+	protected boolean afterSave(boolean newRecord, boolean success)
+	{
+		if (success && getAD_Session_ID() > 0) {
+			s_sessions.put(getAD_Session_ID(), this);
+		}
+		return success;
+	}
+
+	/**
 	 * 	Session Logout
 	 */
 	public void logout()
 	{
 			setProcessed(true);
 			saveEx();
-			s_sessions.remove(getAD_Session_ID());
 			log.info(TimeUtil.formatElapsed(getCreated(), getUpdated()));
 	}	//	logout
 	


### PR DESCRIPTION
When two JVMs share the same database (e.g. `adempiere-grpc-server` + `adempiere-report-engine-service`), their in-memory caches diverge after writes performed by one of them: the second JVM keeps serving the previous state until TTL. This is most visible after `change-role` — reports run with the wrong tenant/org filter and return empty.

## Changes

- `MSession.afterSave(...)`: new override that refreshes `s_sessions` with the current instance on every successful save. Keeps the cache aligned with the row's actual state (including `Processed`) without an extra DB hit on read. Processed sessions stay visible — callers that need to reject them (e.g. `KeycloakSessionHandler.loadExistingSessionContext`) check `isProcessed()` themselves; callers that need them (audit log, changelog, keepalive on closing sessions) still get the row.
- `MSession.logout()`: dropped the redundant explicit `s_sessions.remove(...)` — `afterSave` already refreshes the entry after `setProcessed(true)` + `saveEx()`.
- `MRole.removeFromCache(int roleId, int userId)`: new static helper to evict a `(role, user)` cache entry so the next `get()` rebuilds the access SQL. Required when the user's effective tenant/org changes.

## Test

Login as System → change role to a company → run a report whose query goes through `MRole.addAccessSQL`. SQL filter must contain the company's `AD_Client_ID` / `AD_Org_ID`, not `0, 0`. Full cross-JVM coverage still requires a distributed cache (out of scope here).