### PR TITLE
Fixed error with recognition reversal date

### DIFF
--- a/base/src/main/java/org/compiere/model/MRevenueRecognitionRun.java
+++ b/base/src/main/java/org/compiere/model/MRevenueRecognitionRun.java
@@ -464,12 +464,12 @@ public class MRevenueRecognitionRun extends X_C_RevenueRecognition_Run implement
 
 	public MRevenueRecognitionRun reverseIt(Timestamp date) {
 		MRevenueRecognitionRun reverse = new MRevenueRecognitionRun(getCtx(), 0, get_TrxName());
+		PO.copyValues(this, reverse);
 		if(date != null) {
 			reverse.setDateDoc(date);
 		} else {
 			reverse.setDateDoc(getDateDoc());
 		}
-		PO.copyValues(this, reverse);
 		reverse.setRecognizedAmt(getRecognizedAmt().negate());
 		reverse.setSourceRecognizedAmt(getSourceRecognizedAmt().negate());
 		reverse.setReversal(true);


### PR DESCRIPTION
A reversal from revenue recognition must be accrual. The problem here is that this reversal was with current date