### PR TITLE
feat(eca62): add presigned URL, delete and exists methods to IS3 

### DIFF
--- a/base/src/main/java/org/spin/eca62/setup/Deploy.java
+++ b/base/src/main/java/org/spin/eca62/setup/Deploy.java
@@ -16,14 +16,14 @@
  *****************************************************************************/
 package org.spin.eca62.setup;
 
-import java.util.Properties;
-
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MClientInfo;
 import org.compiere.util.Env;
 import org.spin.model.MADAppRegistration;
 import org.spin.model.MADAppSupport;
 import org.spin.util.ISetupDefinition;
+
+import java.util.Properties;
 
 /**
  * Create App Registration to Connect to local minio

--- a/base/src/main/java/org/spin/eca62/support/IS3.java
+++ b/base/src/main/java/org/spin/eca62/support/IS3.java
@@ -59,4 +59,40 @@ public interface IS3 {
 	 */
 	public List<String> getResourceFileNames(ResourceMetadata resourceMetadata) throws Exception;
 
+	/**
+	 * Generate a pre-signed URL to upload (PUT) a resource directly to the storage.
+	 * The client uploads the bytes straight to the storage, the server never carries them.
+	 * @param resourceMetadata resource location (Client, container Type, Table, Record ID, name)
+	 * @param contentType optional content type to bind to the signature (may be null/empty)
+	 * @param expirationSeconds time to live of the signed URL in seconds
+	 * @return signed URL
+	 * @throws Exception
+	 */
+	public String getUploadPresignedUrl(ResourceMetadata resourceMetadata, String contentType, int expirationSeconds) throws Exception;
+
+	/**
+	 * Generate a pre-signed URL to download (GET) a resource directly from the storage.
+	 * Serves both download and inline visualization of images.
+	 * @param resourceMetadata resource location
+	 * @param expirationSeconds time to live of the signed URL in seconds
+	 * @return signed URL
+	 * @throws Exception
+	 */
+	public String getDownloadPresignedUrl(ResourceMetadata resourceMetadata, int expirationSeconds) throws Exception;
+
+	/**
+	 * Delete a resource based on metadata
+	 * @param resourceMetadata resource location
+	 * @throws Exception
+	 */
+	public void deleteResource(ResourceMetadata resourceMetadata) throws Exception;
+
+	/**
+	 * Verify if a resource exists based on metadata
+	 * @param resourceMetadata resource location
+	 * @return true if the object exists in the storage
+	 * @throws Exception
+	 */
+	public boolean exists(ResourceMetadata resourceMetadata) throws Exception;
+
 }

--- a/base/src/main/java/org/spin/eca62/support/S3.java
+++ b/base/src/main/java/org/spin/eca62/support/S3.java
@@ -17,6 +17,7 @@
  *****************************************************************************/
 package org.spin.eca62.support;
 
+import com.amazonaws.HttpMethod;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -36,6 +37,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -360,6 +362,40 @@ public class S3 implements IWebDav, IS3 {
 			throw new AdempiereException(e);
 		}
 		return fileNames;
+	}
+
+	@Override
+	public String getUploadPresignedUrl(ResourceMetadata resourceMetadata, String contentType, int expirationSeconds) throws Exception {
+		AmazonS3 s3Client = getS3Instance();
+		String key = resourceMetadata.getResourceFileName();
+		Date expiration = new Date(System.currentTimeMillis() + (expirationSeconds * 1000L));
+		GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(getBucketName(), key, HttpMethod.PUT)
+			.withExpiration(expiration);
+		if(!Util.isEmpty(contentType, true)) {
+			request.setContentType(contentType);
+		}
+		return s3Client.generatePresignedUrl(request).toString();
+	}
+
+	@Override
+	public String getDownloadPresignedUrl(ResourceMetadata resourceMetadata, int expirationSeconds) throws Exception {
+		AmazonS3 s3Client = getS3Instance();
+		String key = resourceMetadata.getResourceFileName();
+		Date expiration = new Date(System.currentTimeMillis() + (expirationSeconds * 1000L));
+		GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(getBucketName(), key, HttpMethod.GET)
+			.withExpiration(expiration);
+		return s3Client.generatePresignedUrl(request).toString();
+	}
+
+	@Override
+	public void deleteResource(ResourceMetadata resourceMetadata) throws Exception {
+		AmazonS3 s3Client = getS3Instance();
+		s3Client.deleteObject(new DeleteObjectRequest(getBucketName(), resourceMetadata.getResourceFileName()));
+	}
+
+	@Override
+	public boolean exists(ResourceMetadata resourceMetadata) throws Exception {
+		return getS3Instance().doesObjectExist(getBucketName(), resourceMetadata.getResourceFileName());
 	}
 
 }

--- a/base/src/main/java/org/spin/eca62/support/S3Resource.java
+++ b/base/src/main/java/org/spin/eca62/support/S3Resource.java
@@ -16,13 +16,12 @@
  *****************************************************************************/
 package org.spin.eca62.support;
 
-import java.sql.Timestamp;
-import java.util.Date;
-
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.adempiere.exceptions.AdempiereException;
 import org.spin.util.support.webdav.IWebDavResource;
 
-import com.amazonaws.services.s3.model.S3ObjectSummary;
+import java.sql.Timestamp;
+import java.util.Date;
 
 /**
  * Resource wrapper for Amazon S3 API

--- a/base/src/main/java/org/spin/eca62/util/S3Manager.java
+++ b/base/src/main/java/org/spin/eca62/util/S3Manager.java
@@ -17,9 +17,6 @@
  *****************************************************************************/
 package org.spin.eca62.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MClientInfo;
 import org.compiere.util.Env;
@@ -28,6 +25,9 @@ import org.spin.eca62.support.ResourceMetadata;
 import org.spin.model.MADAppRegistration;
 import org.spin.util.support.AppSupportHandler;
 import org.spin.util.support.IAppSupport;
+
+import java.io.File;
+import java.io.FileInputStream;
 
 /**
  * Handle S3 Util Manager


### PR DESCRIPTION
feat(eca62): add presigned URL, delete and exists methods to IS3

Extend the IS3 storage abstraction with the standard object operations
that were missing for a presigned-URL based workflow, keeping all S3
logic inside the library.

IS3.java:
- getUploadPresignedUrl(ResourceMetadata, contentType, expirationSeconds)
- getDownloadPresignedUrl(ResourceMetadata, expirationSeconds)
- deleteResource(ResourceMetadata)
- exists(ResourceMetadata)

S3.java:
- Implement the four methods over the existing AWS SDK v1 client using
  generatePresignedUrl (HttpMethod.PUT/GET), deleteObject and
  doesObjectExist, reusing getBucketName() and
  ResourceMetadata.getResourceFileName() for the object key.
- contentType is bound to the PUT signature only when provided.

This lets callers sign upload/download URLs so the client transfers
bytes directly to/from S3, while bucket/region/credentials keep being
resolved from the per-client FileHandler (AD_AppRegistration).