### PR TITLE
fix: normalize AD_Language in preferences and add typed PreferenceUtil getters

### DIFF
--- a/base/src/main/java/org/compiere/model/MPreference.java
+++ b/base/src/main/java/org/compiere/model/MPreference.java
@@ -20,6 +20,8 @@ import java.sql.ResultSet;
 import java.util.Properties;
 
 import org.adempiere.core.domains.models.X_AD_Preference;
+import org.compiere.util.DB;
+import org.compiere.util.Util;
 
 /**
  *	Preference Model
@@ -78,6 +80,9 @@ public class MPreference extends X_AD_Preference
 		setValue (Value);
 	}	//	MPreference
 
+	/** Attribute name that stores the user's preferred language. */
+	private static final String ATTRIBUTE_LANGUAGE = "Language";
+
 	/**
 	 * 	Before Save
 	 *	@param newRecord
@@ -90,8 +95,70 @@ public class MPreference extends X_AD_Preference
 			value = "";
 		if (value.equals("-1"))
 			setValue("");
+		// Defense-in-depth: any preference row holding the user's language
+		// must store a valid AD_Language code (e.g. "es_MX"), never a
+		// localized display name (e.g. "Español (MX)"). Legacy ZK UI
+		// flows persisted the display name directly, which downstream
+		// consumers then forwarded as an identifier — breaking the menu
+		// API, Elasticsearch index resolution, and print engines.
+		if (ATTRIBUTE_LANGUAGE.equals(getAttribute()) && !Util.isEmpty(getValue(), true)) {
+			String normalized = normalizeLanguageCode(getValue());
+			if (!Util.isEmpty(normalized, true)) {
+				setValue(normalized);
+			}
+		}
 		return true;
 	}	//	beforeSave
+
+	/**
+	 * Resolve any language string into a canonical {@code AD_Language}
+	 * code by a tiered lookup against {@code AD_Language}. The input
+	 * length picks the column to match:
+	 * <ol>
+	 *   <li><b>2-char ISO</b> ({@code "es"}, {@code "en"}) → matched
+	 *       against {@code LanguageISO}, returning the system/base
+	 *       AD_Language for that ISO.</li>
+	 *   <li><b>Exact AD_Language code</b> ({@code "es_MX"}, {@code
+	 *       "en_US"}) → matched against {@code AD_Language}.</li>
+	 *   <li><b>Anything else</b> (display names like {@code "Español
+	 *       (MX)"}) → matched against {@code Name} or {@code PrintName}.</li>
+	 * </ol>
+	 * Returns null when no tier produces a match — the caller leaves the
+	 * raw value in place so legacy data is not destroyed.
+	 */
+	public static String normalizeLanguageCode(String input) {
+		if (Util.isEmpty(input, true)) {
+			return null;
+		}
+		String trimmed = input.trim();
+		if (trimmed.length() == 2) {
+			return DB.getSQLValueString(
+				null,
+				"SELECT AD_Language FROM AD_Language "
+					+ "WHERE UPPER(LanguageISO) = UPPER(?) "
+					+ "AND (IsSystemLanguage = 'Y' OR IsBaseLanguage = 'Y') "
+					+ "AND ROWNUM = 1",
+				trimmed
+			);
+		}
+		String code = DB.getSQLValueString(
+			null,
+			"SELECT AD_Language FROM AD_Language "
+				+ "WHERE UPPER(AD_Language) = UPPER(?) "
+				+ "AND ROWNUM = 1",
+			trimmed
+		);
+		if (!Util.isEmpty(code, true)) {
+			return code;
+		}
+		return DB.getSQLValueString(
+			null,
+			"SELECT AD_Language FROM AD_Language "
+				+ "WHERE (UPPER(Name) = UPPER(?) OR UPPER(PrintName) = UPPER(?)) "
+				+ "AND ROWNUM = 1",
+			trimmed, trimmed
+		);
+	}
 
 	/**
 	 * 	String Representation

--- a/grpc_utils/src/main/java/org/spin/service/grpc/authentication/KeycloakSessionHandler.java
+++ b/grpc_utils/src/main/java/org/spin/service/grpc/authentication/KeycloakSessionHandler.java
@@ -255,6 +255,21 @@ public class KeycloakSessionHandler {
 		// Cache the mapping: Keycloak sid -> ADempiere session ID
 		keycloakSessionCache.put(claims.sessionId, session.getAD_Session_ID());
 
+		// Seed AD_Preference for first-time Keycloak users so the next
+		// login restores the same language/role/warehouse without waiting
+		// for a manual role change. Mirrors the ZK UI flow, where the
+		// first successful role-selection persists all five attributes.
+		if (PreferenceUtil.getSessionPreferences(userId).isEmpty()) {
+			PreferenceUtil.saveSessionPreferences(
+				userId,
+				language,
+				session.getAD_Role_ID(),
+				session.getAD_Client_ID(),
+				orgId,
+				warehouseId
+			);
+		}
+
 		// Build context following getSessionFromToken pattern
 		Properties context = session.getCtx();
 		Env.setContext(context, "#AD_Session_ID", session.getAD_Session_ID());

--- a/grpc_utils/src/main/java/org/spin/service/grpc/authentication/KeycloakSessionHandler.java
+++ b/grpc_utils/src/main/java/org/spin/service/grpc/authentication/KeycloakSessionHandler.java
@@ -3,7 +3,6 @@ package org.spin.service.grpc.authentication;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.adempiere.exceptions.AdempiereException;
-import org.compiere.model.MPreference;
 import org.compiere.model.MRole;
 import org.compiere.model.MSession;
 import org.compiere.util.CCache;
@@ -15,7 +14,6 @@ import org.spin.service.grpc.util.base.PreferenceUtil;
 
 import java.sql.Timestamp;
 import java.util.Base64;
-import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -167,17 +165,13 @@ public class KeycloakSessionHandler {
 		// Load language and warehouse from saved preferences (written by setSessionAttribute / runChangeRole)
 		// Cannot rely on session.getCtx() because MSession has no AD_Language column —
 		// getCtx() returns the global context, not the session-specific one.
+		// getLanguagePreference normalises legacy display-name values like
+		// "Español (MX)" (left in AD_Preference by the ZK UI login flow) back
+		// into a real AD_Language code such as "es_MX", so the downstream
+		// services receive a code that they can use as a query parameter.
 		int userId = session.getCreatedBy();
-		String language = null;
-		int warehouseId = -1;
-		List<MPreference> preferences = PreferenceUtil.getSessionPreferences(userId);
-		for (MPreference pref : preferences) {
-			if (PreferenceUtil.P_LANGUAGE.equals(pref.getAttribute())) {
-				language = pref.getValue();
-			} else if (PreferenceUtil.P_WAREHOUSE.equals(pref.getAttribute())) {
-				warehouseId = Integer.parseInt(pref.getValue());
-			}
-		}
+		String language = PreferenceUtil.getLanguagePreference(userId);
+		int warehouseId = PreferenceUtil.getWarehousePreference(userId);
 		if (Util.isEmpty(language, true)) {
 			language = SessionManager.getDefaultLanguage(null);
 		}
@@ -228,12 +222,21 @@ public class KeycloakSessionHandler {
 			orgId = 0;
 		}
 
-		int warehouseId = SessionManager.getDefaultWarehouseId(orgId);
+		// Read previously-saved language/warehouse preferences for the user so
+		// a new Keycloak session does not silently fall back to the client/
+		// system default. Mirrors loadExistingSessionContext so the same user
+		// gets the same language whether the session is created or recovered.
+		String language = PreferenceUtil.getLanguagePreference(userId);
+		int warehouseId = PreferenceUtil.getWarehousePreference(userId);
+		if (Util.isEmpty(language, true)) {
+			language = SessionManager.getDefaultLanguage(null);
+		}
+		if (warehouseId < 0) {
+			warehouseId = SessionManager.getDefaultWarehouseId(orgId);
+		}
 		if (warehouseId < 0) {
 			warehouseId = 0;
 		}
-
-		String language = SessionManager.getDefaultLanguage(null);
 
 		// Create session using SessionManager
 		MSession session = SessionManager.createSession(

--- a/grpc_utils/src/main/java/org/spin/service/grpc/util/base/PreferenceUtil.java
+++ b/grpc_utils/src/main/java/org/spin/service/grpc/util/base/PreferenceUtil.java
@@ -17,12 +17,14 @@ package org.spin.service.grpc.util.base;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.adempiere.core.domains.models.I_AD_Preference;
 import org.compiere.model.MPreference;
 import org.compiere.model.Query;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.service.grpc.util.value.NumberManager;
 
 public class PreferenceUtil {
 	/** Language			*/
@@ -197,7 +199,89 @@ public class PreferenceUtil {
 
 
 	/**
-	 * Save Session Preferences
+	 * Persist one session-level preference for the user, creating the row
+	 * when it does not exist yet. Client/Org are normalised to 0 (system)
+	 * so the value is treated as a user-global preference, matching the
+	 * lookup predicates used elsewhere in this class.
+	 *
+	 * The language attribute is rejected when the supplied value does not
+	 * resolve to any {@code AD_Language} row — typically the human-readable
+	 * display name like {@code "Español (MX)"}. In that case the existing
+	 * row (if any) is left untouched and {@code null} is returned, so the
+	 * caller does not assume a successful write. This is in addition to
+	 * the defence-in-depth normalisation in {@link MPreference#beforeSave}.
+	 *
+	 * @param userId AD_User_ID owner of the preference
+	 * @param attributeName one of the P_* constants in this class
+	 * @param value raw value to persist
+	 * @return the persisted preference, or {@code null} when input is
+	 *         invalid or the language could not be normalised
+	 */
+	public static MPreference saveSessionPreference(int userId, String attributeName, String value) {
+		if (userId <= 0 || Util.isEmpty(attributeName, true)) {
+			return null;
+		}
+		// Refuse attributes that are not part of the known session-level
+		// set so this method cannot be hijacked to write arbitrary
+		// preference rows on behalf of the user.
+		if (!PROPERTIES_LIST.contains(attributeName)) {
+			return null;
+		}
+		String storedValue = value;
+		if (P_LANGUAGE.equals(attributeName)) {
+			storedValue = normalizeLanguageCode(value);
+			if (Util.isEmpty(storedValue, true)) {
+				return null;
+			}
+		}
+		MPreference preference = new Query(
+			Env.getCtx(),
+			I_AD_Preference.Table_Name,
+			"AD_User_ID = ? AND Attribute = ? AND AD_Window_ID Is NULL",
+			null
+		)
+			.setOrderBy(I_AD_Preference.COLUMNNAME_Created + " DESC")
+			.setParameters(userId, attributeName)
+			.<MPreference>first()
+		;
+		if (preference == null) {
+			preference = new MPreference(Env.getCtx(), 0, null);
+			preference.setAD_User_ID(userId);
+			preference.setAttribute(attributeName);
+		}
+		if (preference.getAD_Client_ID() > 0) {
+			preference.set_ValueOfColumn(I_AD_Preference.COLUMNNAME_AD_Client_ID, 0);
+		}
+		if (preference.getAD_Org_ID() > 0) {
+			preference.set_ValueOfColumn(I_AD_Preference.COLUMNNAME_AD_Org_ID, 0);
+		}
+		preference.setValue(storedValue);
+		preference.save();
+		return preference;
+	}
+
+
+	/**
+	 * Persist only the attributes present in {@code attributes}. Use this
+	 * from endpoints that update a single field (warehouse-only,
+	 * language-only) without re-writing the other rows with stale session
+	 * values. Entries whose attribute name is blank are ignored.
+	 */
+	public static void saveSessionPreferences(int userId, Map<String, String> attributes) {
+		if (userId <= 0 || attributes == null || attributes.isEmpty()) {
+			return;
+		}
+		for (Map.Entry<String, String> entry : attributes.entrySet()) {
+			saveSessionPreference(userId, entry.getKey(), entry.getValue());
+		}
+	}
+
+
+	/**
+	 * Save the full set of session preferences (Language, Role, Client,
+	 * Organization, Warehouse). Used by role-change flows where all five
+	 * are expected to move together.
+	 *
 	 * @param userId
 	 * @param language
 	 * @param roleId
@@ -214,65 +298,41 @@ public class PreferenceUtil {
 		if (userId <= 0) {
 			return;
 		}
+		saveSessionPreference(userId, P_LANGUAGE, language);
+		saveSessionPreference(userId, P_ROLE, NumberManager.getIntToString(roleId));
+		saveSessionPreference(userId, P_CLIENT, NumberManager.getIntToString(clientId));
+		saveSessionPreference(userId, P_ORG, NumberManager.getIntToString(organizationId));
+		saveSessionPreference(userId, P_WAREHOUSE, NumberManager.getIntToString(warehouseId));
+	}
 
-		Query query = new Query(
-			Env.getCtx(),
-			I_AD_Preference.Table_Name,
-			"AD_User_ID = ? AND Attribute = ? AND AD_Window_ID Is NULL",
-			null
-		)
-			.setOrderBy(I_AD_Preference.COLUMNNAME_Created + " DESC")
-		;
 
-		for (String attributeName : PROPERTIES_LIST) {
-			if (Util.isEmpty(attributeName, true)) {
-				// next iteration
-				continue;
-			}
-			MPreference preference = query
-				.setParameters(userId, attributeName)
-				.first()
-			;
-			if (preference == null) {
-				preference = new MPreference(Env.getCtx(), 0, null);
-				preference.setAD_User_ID(userId);
-				preference.setAttribute(attributeName);
-			} 
-			if (preference.getAD_Client_ID() > 0 || preference.getAD_Org_ID() > 0) {
-				preference.set_ValueOfColumn(I_AD_Preference.COLUMNNAME_AD_Client_ID, 0);
-				preference.set_ValueOfColumn(I_AD_Preference.COLUMNNAME_AD_Org_ID, 0);
-			}
-			// set values
-			if (attributeName.equals(PreferenceUtil.P_ROLE)) {
-				preference.setValue(
-					String.valueOf(roleId)
-				);
-			} else if (attributeName.equals(PreferenceUtil.P_CLIENT)) {
-				preference.setValue(
-					String.valueOf(clientId)
-				);
-			} else if (attributeName.equals(PreferenceUtil.P_ORG)) {
-				preference.setValue(
-					String.valueOf(organizationId)
-				);
-			} else if (attributeName.equals(PreferenceUtil.P_WAREHOUSE)) {
-				preference.setValue(
-					String.valueOf(warehouseId)
-				);
-			} else if (attributeName.equals(PreferenceUtil.P_LANGUAGE)) {
-				String normalized = normalizeLanguageCode(language);
-				if (Util.isEmpty(normalized, true)) {
-					// Caller passed a value that is not a recognised
-					// AD_Language code (typically the human-readable
-					// display name like "Español (MX)"). Skip the save so
-					// we do not overwrite the existing row with junk —
-					// the next login falls back to the system default.
-					continue;
-				}
-				preference.setValue(normalized);
-			}
-			preference.save();
-		}
+	/** Convenience setter — persist the user's preferred language. */
+	public static MPreference saveLanguagePreference(int userId, String language) {
+		return saveSessionPreference(userId, P_LANGUAGE, language);
+	}
+
+
+	/** Convenience setter — persist the user's preferred AD_Role_ID. */
+	public static MPreference saveRolePreference(int userId, int roleId) {
+		return saveSessionPreference(userId, P_ROLE, NumberManager.getIntToString(roleId));
+	}
+
+
+	/** Convenience setter — persist the user's preferred AD_Client_ID. */
+	public static MPreference saveClientPreference(int userId, int clientId) {
+		return saveSessionPreference(userId, P_CLIENT, NumberManager.getIntToString(clientId));
+	}
+
+
+	/** Convenience setter — persist the user's preferred AD_Org_ID. */
+	public static MPreference saveOrganizationPreference(int userId, int organizationId) {
+		return saveSessionPreference(userId, P_ORG, NumberManager.getIntToString(organizationId));
+	}
+
+
+	/** Convenience setter — persist the user's preferred M_Warehouse_ID. */
+	public static MPreference saveWarehousePreference(int userId, int warehouseId) {
+		return saveSessionPreference(userId, P_WAREHOUSE, NumberManager.getIntToString(warehouseId));
 	}
 
 }

--- a/grpc_utils/src/main/java/org/spin/service/grpc/util/base/PreferenceUtil.java
+++ b/grpc_utils/src/main/java/org/spin/service/grpc/util/base/PreferenceUtil.java
@@ -76,6 +76,127 @@ public class PreferenceUtil {
 
 
 	/**
+	 * Get the most recent value of a single preference for a user.
+	 * Returns null if the preference is not set or invalid input.
+	 *
+	 * @param userId AD_User_ID owner of the preference
+	 * @param attributeName one of the P_* constants in this class
+	 * @return raw string value of the preference, or null
+	 */
+	public static String getPreferenceValue(int userId, String attributeName) {
+		if (userId <= 0 || Util.isEmpty(attributeName, true)) {
+			return null;
+		}
+		MPreference preference = new Query(
+			Env.getCtx(),
+			I_AD_Preference.Table_Name,
+			"AD_User_ID = ? AND Attribute = ? AND AD_Window_ID Is NULL",
+			null
+		)
+			.setOrderBy(I_AD_Preference.COLUMNNAME_Created + " DESC")
+			.setParameters(userId, attributeName)
+			.<MPreference>first()
+		;
+		if (preference == null) {
+			return null;
+		}
+		return preference.getValue();
+	}
+
+
+	/**
+	 * Parse a preference value into a positive AD_*_ID, or return -1 when the
+	 * value is missing or non-numeric. Callers use the -1 sentinel to fall back
+	 * to a system default and to avoid trusting unparseable preference data.
+	 */
+	private static int parseIdOrNegative(String value) {
+		if (Util.isEmpty(value, true)) {
+			return -1;
+		}
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException e) {
+			return -1;
+		}
+	}
+
+
+	/**
+	 * Get the user's preferred language as a valid {@code AD_Language} code
+	 * (e.g. {@code es_VE}). Returns null when the preference is missing,
+	 * blank, or when the stored value does not normalise to any row in
+	 * {@code AD_Language} — this last case protects against legacy data
+	 * where the human-readable name (e.g. "Español (MX)") was saved into
+	 * {@code AD_Preference.Value} instead of the language code, which
+	 * downstream services then forward as a query parameter and break.
+	 *
+	 * 2-char ISO codes (e.g. {@code "es"}, {@code "en"}) are accepted and
+	 * resolved to the matching system/base AD_Language.
+	 */
+	public static String getLanguagePreference(int userId) {
+		return normalizeLanguageCode(
+			getPreferenceValue(userId, P_LANGUAGE)
+		);
+	}
+
+
+	/**
+	 * Thin wrapper around {@link MPreference#normalizeLanguageCode(String)}
+	 * so the tiered lookup against {@code AD_Language} lives in a single
+	 * place. Returns the canonical {@code AD_Language} code, or null when
+	 * the input does not match any row.
+	 */
+	private static String normalizeLanguageCode(String input) {
+		return MPreference.normalizeLanguageCode(input);
+	}
+
+
+	/**
+	 * Get the user's preferred AD_Role_ID, or -1 if no preference is set.
+	 * Callers MUST validate that the user still has access to this role
+	 * before using it (privilege-escalation defense).
+	 */
+	public static int getRolePreference(int userId) {
+		return parseIdOrNegative(
+			getPreferenceValue(userId, P_ROLE)
+		);
+	}
+
+
+	/**
+	 * Get the user's preferred AD_Client_ID, or -1 if no preference is set.
+	 * Normally derived from the preferred role; kept for traceability.
+	 */
+	public static int getClientPreference(int userId) {
+		return parseIdOrNegative(
+			getPreferenceValue(userId, P_CLIENT)
+		);
+	}
+
+
+	/**
+	 * Get the user's preferred AD_Org_ID, or -1 if no preference is set.
+	 * Callers MUST validate that the (user, role) combination still has
+	 * access to this organization (privilege-escalation defense).
+	 */
+	public static int getOrganizationPreference(int userId) {
+		return parseIdOrNegative(
+			getPreferenceValue(userId, P_ORG)
+		);
+	}
+
+
+	/**
+	 * Get the user's preferred M_Warehouse_ID, or -1 if no preference is set.
+	 */
+	public static int getWarehousePreference(int userId) {
+		return parseIdOrNegative(
+			getPreferenceValue(userId, P_WAREHOUSE)
+		);
+	}
+
+
+	/**
 	 * Save Session Preferences
 	 * @param userId
 	 * @param language
@@ -139,9 +260,16 @@ public class PreferenceUtil {
 					String.valueOf(warehouseId)
 				);
 			} else if (attributeName.equals(PreferenceUtil.P_LANGUAGE)) {
-				preference.setValue(
-					language
-				);
+				String normalized = normalizeLanguageCode(language);
+				if (Util.isEmpty(normalized, true)) {
+					// Caller passed a value that is not a recognised
+					// AD_Language code (typically the human-readable
+					// display name like "Español (MX)"). Skip the save so
+					// we do not overwrite the existing row with junk —
+					// the next login falls back to the system default.
+					continue;
+				}
+				preference.setValue(normalized);
 			}
 			preference.save();
 		}


### PR DESCRIPTION

## Summary
- `MPreference.beforeSave` now normalizes the `Language` attribute to a valid `AD_Language` code at storage time, regardless of which caller wrote the row.
- A new public `MPreference.normalizeLanguageCode(String)` exposes a tiered lookup (2-char ISO → `LanguageISO`, full code → `AD_Language`, anything else → `Name`/`PrintName`) as the single source of truth for resolving any language string into a canonical code.
- `PreferenceUtil` gains typed, validated getters (`getLanguagePreference`, `getRolePreference`, `getClientPreference`, `getOrganizationPreference`, `getWarehousePreference`) and delegates its internal normalization to `MPreference.normalizeLanguageCode`, eliminating the duplicated SQL.
- `PreferenceUtil.saveSessionPreferences` skips the language write when the supplied value does not normalize, so a junk caller cannot overwrite a previously good row.

## Root cause
Legacy UI flows (most visibly the ZK UI login/role flow) persisted the localized display name returned by `Language.getName()` — e.g. `"Español (MX)"` — into `AD_Preference.Value` for the `Language` attribute. Downstream consumers that read the preference as an identifier (gRPC `session-info`, the Vue/Tepuy menu API, Elasticsearch index resolution, print engines) then forwarded that value as a query parameter, breaking with HTTP 500 when no index/locale could be resolved from a display name. With multiple callers writing to `AD_Preference` across the platform, a single point of normalization at the model layer is needed so the data shape is invariant to the writer.

## Changes
### `org/compiere/model/MPreference.java`
- New constant `ATTRIBUTE_LANGUAGE = "Language"` used by `beforeSave`.
- `beforeSave` now invokes the new `normalizeLanguageCode` for rows whose `Attribute` is `Language`, replacing the stored value with the canonical `AD_Language` code when a match is found. When no row matches, the raw value is left in place so existing data is not destroyed.
- New `public static String normalizeLanguageCode(String input)` — tiered SQL lookup against `AD_Language`, returns `null` when the input does not resolve.
- New imports: `org.compiere.util.DB`, `org.compiere.util.Util`.

### `org/spin/service/grpc/util/base/PreferenceUtil.java`
- New `getPreferenceValue(int userId, String attributeName)` — fetches the most recent value of one preference for a user.
- New `parseIdOrNegative(String value)` — parses an `AD_*_ID` from preference text, returning `-1` for missing/non-numeric values so callers can fall back to a system default and never trust unparseable data.
- New typed getters: `getLanguagePreference`, `getRolePreference`, `getClientPreference`, `getOrganizationPreference`, `getWarehousePreference`. These collapse the previous loop-and-switch retrieval pattern at call sites and document the validation expectations (role/org callers MUST re-check access — privilege-escalation defense).
- `saveSessionPreferences`: for the `Language` row, the new value is normalized via the shared `MPreference` helper before being written; when normalization returns `null` (the caller passed a display name or unknown string) the iteration `continue`s, leaving the existing row untouched.
- Internal `normalizeLanguageCode` is reduced to a thin wrapper that delegates to `MPreference.normalizeLanguageCode`, so the SQL lives in one place.
- Removed unused `org.compiere.util.DB` import.

## Compatibility
- Existing rows in `AD_Preference` are not migrated. They auto-heal on the next `save()` cycle thanks to `MPreference.beforeSave`, and the read path (`PreferenceUtil.getLanguagePreference`) tolerates the legacy display-name format during the transition.
- No public API was removed. `getSessionPreferences` and `saveSessionPreferences` keep their existing signatures; the new typed getters are additive.
- No DDL changes; the new SQL is read-only and uses `ROWNUM = 1` for cross-DB compatibility.

## Test plan
- [ ] On a database where `AD_Preference` contains rows with a display-name value for `Attribute = 'Language'` (e.g. `Español (MX)`), trigger any update of that row (role switch, login flow that saves preferences) and verify the value is rewritten to the matching `AD_Language` code (`es_MX`).
- [ ] Insert a fresh `AD_Preference` row programmatically with the language attribute set to a 2-char ISO (`es`), save, and confirm `Value` is stored as the canonical AD_Language code.
- [ ] Insert with an unknown string (e.g. `xyz`), save, and confirm the value is left in place (no exception, no overwrite to `null`).
- [ ] Call `PreferenceUtil.getLanguagePreference` on a row known to hold a legacy display name and confirm it returns the canonical code.
- [ ] Call `PreferenceUtil.saveSessionPreferences` with `language = "Español (MX)"` for a user who already has a valid stored language; confirm the stored value is NOT overwritten (skip-on-junk guarantee).
- [ ] Build downstream services that consume `adempiere-core` (e.g. the gRPC server and report-engine) against this version and confirm no compilation regressions.