### PR TITLE
fix: avoid NullPointerException in SequenceCheck when `Created` is null

### DIFF
--- a/base/src/main/java/org/compiere/process/SequenceCheck.java
+++ b/base/src/main/java/org/compiere/process/SequenceCheck.java
@@ -220,7 +220,9 @@ public class SequenceCheck extends SvrProcess
 					MSequence seq = new MSequence (ctx, sequenceId, transactionName);
 					int old = seq.getCurrentNext();
 					int oldSys = seq.getCurrentNextSys();
-					boolean isNewSequence = seq.getCreated().equals(seq.getUpdated());
+					// Created may be null for some sequences; guard against NPE so the
+					// sequence is still validated below.
+					boolean isNewSequence = seq.getCreated() != null && seq.getCreated().equals(seq.getUpdated());
 					if (seq.validateTableIDValue()) {
 						if (seq.getCurrentNext() != old) {
 							String msg = seq.getName() + " ID  "
@@ -317,4 +319,5 @@ public class SequenceCheck extends SvrProcess
 		
 		System.out.println("Process=" + pi.getTitle() + " Error="+pi.isError() + " Summary=" + pi.getSummary());
 	}
+
 }	//	SequenceCheck


### PR DESCRIPTION

## Problem

Running the **Sequence Check** process floods the log with errors like:

```
SequenceCheck.lambda$checkTableID$0: Cannot invoke "java.sql.Timestamp.equals(java.sql.Timestamp)" because the return value of "org.compiere.model.MSequence.getCreated()" is null
```

For every affected sequence the exception is thrown **before** `validateTableIDValue()` runs, so those sequences are never validated or corrected — they are silently skipped.

## Root cause

In `SequenceCheck.checkTableID(...)` the "is new sequence" flag is computed as:

```java
boolean isNewSequence = seq.getCreated().equals(seq.getUpdated());
```

When `MSequence.getCreated()` returns `null`, invoking `.equals(...)` on it throws a `NullPointerException`. The receiver of `.equals()` is the only null risk here (a `null` argument is handled safely by `Timestamp.equals`).

## Fix

Guard the comparison against a null `Created` value so the sequence is still validated:

```java
boolean isNewSequence = seq.getCreated() != null && seq.getCreated().equals(seq.getUpdated());
```

When `Created` is `null`, `isNewSequence` becomes `false` (consistent with the previous behavior, where these records never reached the native-sequence-creation branch anyway), and `validateTableIDValue()` now executes as expected.

## How to test

1. Ensure at least one `AD_Sequence` row has `Created` null (or reproduce the original logs).
2. Run the **Sequence Check** process (`org.compiere.process.SequenceCheck`).
3. Before: the log shows repeated `getCreated() is null` NPEs and those sequences are not validated.
4. After: no NPE is thrown and the sequences are validated/corrected normally.

## Notes

- Behavior-preserving, no functional change for sequences with a non-null `Created`.
- Scope limited to the null-safety guard.