### PR TITLE
fix: Skip unloaded `MSequence` records in SequenceCheck to avoid validating blank sequences

### DIFF
--- a/base/src/main/java/org/compiere/process/SequenceCheck.java
+++ b/base/src/main/java/org/compiere/process/SequenceCheck.java
@@ -218,6 +218,13 @@ public class SequenceCheck extends SvrProcess
 			Trx.run(transactionName -> {
 				try {
 					MSequence seq = new MSequence (ctx, sequenceId, transactionName);
+					// The id list is fetched in the main trx, but each record is loaded in a
+					// separate parallel trx that may not see it (MSequence.load: NO Data found),
+					// leaving an empty PO. Skip it instead of validating a blank sequence.
+					if (seq == null || seq.get_ID() != sequenceId.intValue()) {
+						s_log.warning("AD_Sequence_ID=" + sequenceId + " could not be loaded, skipping");
+						return;
+					}
 					int old = seq.getCurrentNext();
 					int oldSys = seq.getCurrentNextSys();
 					boolean isNewSequence = seq.getCreated().equals(seq.getUpdated());


### PR DESCRIPTION
## Problem

Running the **Sequence Check** process logs errors like:

```
MSequence.load: NO Data found for AD_Sequence_ID=2001110
```

The sequence id is returned by the query but then fails to load, so the process operates on an empty Persistent Object (null `Created`, etc.) and either throws or validates a blank sequence.

## Root cause

In `SequenceCheck.checkTableID(...)` the list of ids is fetched in the main transaction:

```java
List<Integer> sequenceIds = new Query(ctx, I_AD_Sequence.Table_Name, whereClause, ...).getIDsAsList();
```

but each record is then loaded inside a **separate** transaction created per item by `Trx.run(...)` within a parallel stream. That new transaction may not see the record (transaction isolation / not-yet-committed data), so `new MSequence(ctx, sequenceId, transactionName)` performs a failed `load()` (`MSequence.load: NO Data found`) and returns an empty PO.

## Fix

Detect the failed load and skip the record before using it:

```java
MSequence seq = new MSequence (ctx, sequenceId, transactionName); if (seq.get_ID() != sequenceId.intValue()) {
    s_log.warning("AD_Sequence_ID=" + sequenceId + " could not be loaded, skipping");
    return;
}
```

When the PO did not load, its id will not match the requested `sequenceId`, so the record is skipped instead of being validated as a blank sequence.

## How to test

1. Reproduce the original condition (an `AD_Sequence` id returned by the query but not visible to the per-item transaction).
2. Run the **Sequence Check** process (`org.compiere.process.SequenceCheck`).
3. Before: `NO Data found` followed by NPEs / blank-sequence validation.
4. After: a single `WARNING` per skipped id, no NPE, valid sequences processed normally.