### PR TITLE
Unify password hashing with BCrypt (Sabana / Spring Boot compatible)

### DIFF
--- a/base/src/main/java/org/compiere/model/MUser.java
+++ b/base/src/main/java/org/compiere/model/MUser.java
@@ -323,7 +323,11 @@ public class MUser extends X_AD_User
 	}	//	setValue
 	
 	/**
-	 * Convert Password to SHA-512 hash with salt * 1000 iterations https://www.owasp.org/index.php/Hashing_Java
+	 * Hash the password using the active Secure provider. With the default provider
+	 * (SecureBCrypt) it stores a self-contained BCrypt hash (matching Sabana / Spring
+	 * Boot) and clears AD_User.Salt. If the active provider has no self-contained
+	 * hashing (getPasswordHash returns null), it falls back to the legacy SHA-512 hash
+	 * with a salt * 1000 iterations.
 	 * @param password -- plain text password
 	 */
 	@Override
@@ -339,8 +343,16 @@ public class MUser extends X_AD_User
 			return;
 		
 		hashed = true;   // prevents double call from beforeSave
-		
-		// Uses a secure Random not a simple Random
+
+		//	Self-contained hash from the active Secure provider (BCrypt with SecureBCrypt, Sabana-compatible)
+		String selfContainedHash = SecureEngine.getPasswordHash(password);
+		if (selfContainedHash != null) {
+			super.setPassword(selfContainedHash);
+			setSalt(null);
+			return;
+		}
+
+		//	Legacy SHA-512 hash with salt * 1000 iterations https://www.owasp.org/index.php/Hashing_Java
 		SecureRandom random;
 		try {
 			random = SecureRandom.getInstance("SHA1PRNG");
@@ -348,10 +360,8 @@ public class MUser extends X_AD_User
 			byte[] bSalt = new byte[8];
 			random.nextBytes(bSalt);
 			// Digest computation
-			String hash;
-			hash = SecureEngine.getSHA512Hash(1000,password,bSalt);
-
-	        String sSalt = Secure.convertToHexString(bSalt);
+			String hash = SecureEngine.getSHA512Hash(1000, password, bSalt);
+			String sSalt = Secure.convertToHexString(bSalt);
 			super.setPassword(hash);
 			setSalt(sSalt);
 		} catch (NoSuchAlgorithmException e) {
@@ -394,20 +404,12 @@ public class MUser extends X_AD_User
 	 * check if hashed password matches
 	 */
 	public boolean authenticateHash (String password)  {
-
-		String hash = null;
-		String salt = null;
-
-		hash = getPassword();
-		salt = getSalt();
-
-		// always do calculation to prevent timing based attacks
-		if ( hash == null )
-			hash = "0000000000000000";
-		if ( salt == null )
-			salt = "0000000000000000";
-
-        return MUser.authenticateHash(password, hash , salt);		
+		// Accepts both BCrypt (new) and legacy SHA-512 + salt hashes
+		return SecureEngine.isValidPasswordHash(
+			password,
+			getPassword(),
+			getSalt()
+		);
 	}
 	
 	/**

--- a/base/src/main/java/org/compiere/util/Login.java
+++ b/base/src/main/java/org/compiere/util/Login.java
@@ -338,25 +338,55 @@ public class Login
 	        if(app_pwd == null) {
 	        	return -1;
 	        }
-			//	
-	        if(userSalt == null) {
-	        	if(app_pwd.equals(userPwd)) {
-					authenticatedUserId = userId;
-	        		return userId;
-	        	}
-	        }
-	        //	Match Password
-			if (userSalt != null && MUser.authenticateHash(app_pwd, userPwd , userSalt)) {
+			//	Match password: BCrypt (Sabana) or legacy SHA-512 + salt
+			if (SecureEngine.isValidPasswordHash(app_pwd, userPwd, userSalt)) {
+				upgradePasswordHashOnLogin(userId, app_pwd, isEncrypted, userPwd);
 				authenticatedUserId = userId;
 				return userId;
 			}
-			//	
+			//	Legacy plain text fallback (no salt, not hashed)
+			if (userSalt == null && app_pwd.equals(userPwd)) {
+				upgradePasswordHashOnLogin(userId, app_pwd, isEncrypted, userPwd);
+				authenticatedUserId = userId;
+				return userId;
+			}
+			//
 			return -1;
         }
 		authenticatedUserId = userId;
         return userId;
 	}
-	
+
+	/**
+	 * Lazily upgrade a stored password that is not in the active provider's format
+	 * (legacy SHA-512 + salt, or plain text) to that format (BCrypt with SecureBCrypt)
+	 * after a successful login. No-op when the column is data-storage encrypted, the
+	 * stored value is already self-contained ($2...), or the active provider has no
+	 * self-contained hashing (e.g. the legacy Secure provider).
+	 * @param userId AD_User_ID
+	 * @param plainPassword the plain password just verified
+	 * @param isEncrypted whether AD_User.Password uses column data-storage encryption
+	 * @param storedHash the value currently stored in AD_User.Password
+	 */
+	private void upgradePasswordHashOnLogin(int userId, String plainPassword, boolean isEncrypted, String storedHash) {
+		if (isEncrypted || SecureEngine.isPasswordHashEncrypted(storedHash)) {
+			return;
+		}
+		//	Only upgrade when the active provider produces a self-contained hash (BCrypt)
+		if (SecureEngine.getPasswordHash(plainPassword) == null) {
+			return;
+		}
+		try {
+			MUser user = MUser.get(m_ctx, userId);
+			if (user != null) {
+				user.setPassword(plainPassword);
+				user.saveEx();
+			}
+		} catch (Exception e) {
+			log.warning("Could not upgrade password hash for AD_User_ID=" + userId + ": " + e.getMessage());
+		}
+	}	//	upgradePasswordHashOnLogin
+
 	/**
 	 *  Actual DB login procedure.
 	 *  @param app_user user

--- a/base/src/main/java/org/compiere/util/Secure.java
+++ b/base/src/main/java/org/compiere/util/Secure.java
@@ -413,5 +413,53 @@ public class Secure implements SecureInterface
 			.append ("]");
 		return sb.toString ();
 	}	//	toString
-	
+
+	/**
+	 * 	Is the stored value a BCrypt hash (starts with the $2 version prefix).
+	 */
+	@Override
+	public boolean isPasswordHashEncrypted (String storedHash)
+	{
+		return storedHash != null && storedHash.startsWith("$2");
+	}
+
+	/**
+	 * 	Legacy provider: no self-contained password hash. Returns null so the caller
+	 * 	uses the SHA-512 + AD_User.Salt mechanism.
+	 */
+	@Override
+	public String getPasswordHash (String plainPassword)
+	{
+		return null;
+	}
+
+	/**
+	 * 	Verify against the legacy SHA-512 + AD_User.Salt format.
+	 */
+	@Override
+	public boolean isValidPasswordHash (String plainPassword, String storedHash, String storedSalt)
+	{
+		if (plainPassword == null || storedHash == null)
+			return false;
+		//	SHA-512 hash requires the salt stored alongside it
+		if (storedSalt != null)
+		{
+			try {
+				return getSHA512Hash(1000, plainPassword, convertHexString(storedSalt)).equals(storedHash);
+			} catch (Exception e) {
+				return false;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * 	Verify against a self-contained stored hash (no separate salt).
+	 */
+	@Override
+	public boolean isValidPasswordHash (String plainPassword, String storedHash)
+	{
+		return isValidPasswordHash(plainPassword, storedHash, null);
+	}
+
 }   //  Secure

--- a/base/src/main/java/org/compiere/util/SecureEngine.java
+++ b/base/src/main/java/org/compiere/util/SecureEngine.java
@@ -89,6 +89,59 @@ public class SecureEngine
 	}	//	getDigest
 	
 	/**
+	 *  Self-contained password hash from the active provider (e.g. BCrypt).
+	 *  @param plainPassword plain text password
+	 *  @return self-contained hash, or null when the provider uses legacy SHA-512 + salt
+	 */
+	public static String getPasswordHash(String plainPassword)
+	{
+		if (s_engine == null) {
+			init(System.getProperties());
+		}
+		return s_engine.implementation.getPasswordHash(plainPassword);
+	}	//	getPasswordHash
+
+	/**
+	 *  Verify a plain password against the stored hash (BCrypt or legacy SHA-512 + salt).
+	 *  @param plainPassword plain text password
+	 *  @param storedHash value stored in AD_User.Password
+	 *  @param storedSalt value stored in AD_User.Salt (may be null for BCrypt)
+	 *  @return true when the password matches
+	 */
+	public static boolean isValidPasswordHash(String plainPassword, String storedHash, String storedSalt)
+	{
+		if (s_engine == null) {
+			init(System.getProperties());
+		}
+		return s_engine.implementation.isValidPasswordHash(plainPassword, storedHash, storedSalt);
+	}	//	isValidPasswordHash
+
+	/**
+	 *  Verify a plain password against a self-contained stored hash (e.g. BCrypt),
+	 *  i.e. when there is no separate salt.
+	 *  @param plainPassword plain text password
+	 *  @param storedHash value stored in AD_User.Password
+	 *  @return true when the password matches
+	 */
+	public static boolean isValidPasswordHash(String plainPassword, String storedHash)
+	{
+		return isValidPasswordHash(plainPassword, storedHash, null);
+	}	//	isValidPasswordHash
+
+	/**
+	 *  Is the stored value a BCrypt hash (starts with the $2 version prefix).
+	 *  @param storedHash value stored in AD_User.Password
+	 *  @return true when it is a BCrypt hash
+	 */
+	public static boolean isPasswordHashEncrypted (String storedHash)
+	{
+		if (s_engine == null) {
+			init(System.getProperties());
+		}
+		return s_engine.implementation.isPasswordHashEncrypted(storedHash);
+	}	//	isPasswordHashEncrypted
+
+	/**
 	 *  Convert String to Digest.
 	 *  JavaScript version see - http://pajhome.org.uk/crypt/md5/index.html
 	 *
@@ -188,8 +241,8 @@ public class SecureEngine
 		Exception cause = null;
 		try
 		{
-			Class clazz = Class.forName(realClass);
-			implementation = (SecureInterface)clazz.newInstance();
+			Class<?> clazz = Class.forName(realClass);
+			implementation = (SecureInterface) clazz.getDeclaredConstructor().newInstance();
 		}
 		catch (Exception e)
 		{
@@ -197,7 +250,7 @@ public class SecureEngine
 		}
 		if (implementation == null)
 		{
-			String msg = "Could not initialize: " + realClass + " - " + cause.toString()
+			String msg = "Could not initialize: " + realClass + " - " + (cause != null ? cause.toString() : "Unknown error")
 				+ "\nCheck start script parameter ADEMPIERE_SECURE"; 
 			log.severe(msg);
 			System.err.println(msg);

--- a/base/src/main/java/org/compiere/util/SecureInterface.java
+++ b/base/src/main/java/org/compiere/util/SecureInterface.java
@@ -35,8 +35,8 @@ public interface SecureInterface
 {
 	/** Class Name implementing SecureInterface	*/
 	public static final String	ADEMPIERE_SECURE = "ADEMPIERE_SECURE";
-	/** Default Class Name implementing SecureInterface	*/
-	public static final String	ADEMPIERE_SECURE_DEFAULT = "org.compiere.util.Secure";
+	/** Default Class Name implementing SecureInterface (BCrypt provider, Sabana-compatible) */
+	public static final String	ADEMPIERE_SECURE_DEFAULT = "org.solop.security.SecureBCrypt"; // `org.compiere.util.Secure` is the legacy SHA-512 + salt provider
 
 	
 	/** Clear Text Indicator xyz	*/
@@ -138,5 +138,42 @@ public interface SecureInterface
 	 * @throws UnsupportedEncodingException 
 	 */
 	public String getSHA512Hash (int iterations, String value, byte[] salt) throws NoSuchAlgorithmException, UnsupportedEncodingException;
+
+	/**
+	 * 	Is the stored value a BCrypt hash (starts with the $2 version prefix).
+	 * 	@param storedHash value stored in AD_User.Password
+	 * 	@return true when it is a BCrypt hash
+	 */
+	public boolean isPasswordHashEncrypted (String storedHash);
+
+	/**
+	 * 	Self-contained password hash (e.g. BCrypt) for providers that support it.
+	 * 	The legacy provider returns null, signalling the caller to use the SHA-512 +
+	 * 	salt mechanism; the BCrypt provider ({@code SecureBCrypt}) returns a BCrypt
+	 * 	hash. The active provider decides the stored format; there is no separate flag.
+	 * 	@param plainPassword plain text password
+	 * 	@return self-contained hash, or null when this provider has no self-contained hashing
+	 */
+	public String getPasswordHash (String plainPassword);
+
+	/**
+	 * 	Verify a plain password against the stored credentials. The legacy provider
+	 * 	validates the SHA-512 + AD_User.Salt format; the BCrypt provider
+	 * 	({@code SecureBCrypt}) also accepts BCrypt hashes.
+	 * 	@param plainPassword plain text password to check
+	 * 	@param storedHash value stored in AD_User.Password
+	 * 	@param storedSalt value stored in AD_User.Salt (may be null for BCrypt)
+	 * 	@return true when the password matches
+	 */
+	public boolean isValidPasswordHash (String plainPassword, String storedHash, String storedSalt);
+
+	/**
+	 * 	Verify a plain password against a self-contained stored hash (e.g. BCrypt),
+	 * 	i.e. when there is no separate salt.
+	 * 	@param plainPassword plain text password to check
+	 * 	@param storedHash value stored in AD_User.Password
+	 * 	@return true when the password matches
+	 */
+	public boolean isValidPasswordHash (String plainPassword, String storedHash);
 
 }	//	SecureInterface

--- a/base/src/main/java/org/solop/security/SecureBCrypt.java
+++ b/base/src/main/java/org/solop/security/SecureBCrypt.java
@@ -1,0 +1,150 @@
+/************************************************************************************
+ * Copyright (C) 2012-2025 E.R.P. Consultores y Asociados, C.A.                   *
+ * Contributor(s): Edwin Betancourt, EdwinBetanc0urt@outlook.com                  *
+ * This program is free software: you can redistribute it and/or modify           *
+ * it under the terms of the GNU General Public License as published by           *
+ * the Free Software Foundation, either version 2 of the License, or              *
+ * (at your option) any later version.                                            *
+ * This program is distributed in the hope that it will be useful,                *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                 *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                   *
+ * GNU General Public License for more details.                                   *
+ * You should have received a copy of the GNU General Public License              *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.          *
+ ************************************************************************************/
+package org.solop.security;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
+
+import org.compiere.util.Secure;
+import org.compiere.util.SecureInterface;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * Security provider that hashes user passwords with BCrypt, so ADempiere stores
+ * the very same format as the Spring Boot (Sabana) applications that share the
+ * AD_User.Password column.
+ *
+ * It is an independent {@link SecureInterface} implementation (peer of the legacy
+ * {@link Secure}) and the default provider of this distribution
+ * (see {@link SecureInterface#ADEMPIERE_SECURE_DEFAULT}); it can still be
+ * overridden per JVM with {@code -DADEMPIERE_SECURE=<class>}.
+ *
+ * The reversible encryption / digest / SHA-512 operations are delegated to a
+ * {@link Secure} instance, so column encryption and already-encrypted data keep
+ * exactly the legacy behavior. Only the password hashing is BCrypt:
+ * <ul>
+ *   <li>{@link #getPasswordHash(String)} produces a self-contained BCrypt hash.</li>
+ *   <li>{@link #isValidPasswordHash(String, String, String)} verifies both BCrypt
+ *       and the legacy SHA-512 + AD_User.Salt format, so no user is locked out.</li>
+ * </ul>
+ * Whether a new password is written as BCrypt or as legacy SHA-512 depends only on
+ * the active provider: MUser.setPassword stores whatever getPasswordHash returns,
+ * and this provider always produces BCrypt.
+ */
+public class SecureBCrypt implements SecureInterface {
+
+	/** Same defaults as Sabana: {@code new BCryptPasswordEncoder()} (version $2a, cost 10). */
+	private static final BCryptPasswordEncoder ENCODER = new BCryptPasswordEncoder();
+
+	/** Legacy engine used for the reversible encryption / digest operations. */
+	private final Secure legacy = new Secure();
+
+	//	Password hashing (BCrypt) ------------------------------------------------
+
+	@Override
+	public boolean isPasswordHashEncrypted(String storedHash) {
+		return storedHash != null && storedHash.startsWith("$2");
+	}
+
+	@Override
+	public String getPasswordHash(String plainPassword) {
+		return plainPassword == null ? null : ENCODER.encode(plainPassword);
+	}
+
+	@Override
+	public boolean isValidPasswordHash(String plainPassword, String storedHash, String storedSalt) {
+		if (plainPassword == null || storedHash == null) {
+			return false;
+		}
+		if (isPasswordHashEncrypted(storedHash)) {
+			return ENCODER.matches(plainPassword, storedHash);
+		}
+		//	Legacy SHA-512 hash requires the salt stored alongside it
+		if (storedSalt != null) {
+			try {
+				return getSHA512Hash(1000, plainPassword, Secure.convertHexString(storedSalt)).equals(storedHash);
+			} catch (Exception e) {
+				return false;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean isValidPasswordHash(String plainPassword, String storedHash) {
+		return isValidPasswordHash(plainPassword, storedHash, null);
+	}
+
+	//	Reversible encryption / digest (delegated to the legacy engine) ----------
+
+	@Override
+	public String encrypt(String value) {
+		return legacy.encrypt(value);
+	}
+
+	@Override
+	public String decrypt(String value) {
+		return legacy.decrypt(value);
+	}
+
+	@Override
+	public Integer encrypt(Integer value) {
+		return legacy.encrypt(value);
+	}
+
+	@Override
+	public Integer decrypt(Integer value) {
+		return legacy.decrypt(value);
+	}
+
+	@Override
+	public BigDecimal encrypt(BigDecimal value) {
+		return legacy.encrypt(value);
+	}
+
+	@Override
+	public BigDecimal decrypt(BigDecimal value) {
+		return legacy.decrypt(value);
+	}
+
+	@Override
+	public Timestamp encrypt(Timestamp value) {
+		return legacy.encrypt(value);
+	}
+
+	@Override
+	public Timestamp decrypt(Timestamp value) {
+		return legacy.decrypt(value);
+	}
+
+	@Override
+	public String getDigest(String value) {
+		return legacy.getDigest(value);
+	}
+
+	@Override
+	public boolean isDigest(String value) {
+		return legacy.isDigest(value);
+	}
+
+	@Override
+	public String getSHA512Hash(int iterations, String value, byte[] salt)
+			throws NoSuchAlgorithmException, UnsupportedEncodingException {
+		return legacy.getSHA512Hash(iterations, value, salt);
+	}
+
+}	//	SecureBCrypt

--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,8 @@ dependencies {
     api 'net.minidev:json-smart:2.4.8'
     // https://mvnrepository.com/artifact/net.minidev/accessors-smart
     api 'net.minidev:accessors-smart:2.4.8'
+    //  Password hashing compatible with Spring Boot (Sabana): same BCryptPasswordEncoder
+    api 'org.springframework.security:spring-security-crypto:6.5.7'
     //  Service
     api "org.scala-lang:scala3-library_3:3.0.1"
     api "commons-collections:commons-collections:3.2.2"


### PR DESCRIPTION
## Summary
Aligns ADempiere's password hashing with the Spring Boot (Sabana) applications that share the same `AD_User.Password` column, so a password set in either system authenticates in both. New passwords are hashed with the very same `BCryptPasswordEncoder` Sabana uses (`$2a$`, cost 10). Existing SHA-512 + salt passwords keep working and are transparently upgraded to BCrypt on the next successful login. The behavior is controlled per database via a SysConfig flag.

## Context / Problem
- ADempiere stored passwords as SHA-512 (1000 iterations) + `AD_User.Salt`; Sabana stores BCrypt (`$2a$…`, salt embedded, `AD_User.Salt` = null).
- Same table/column, incompatible formats → a password set in one system failed to authenticate in the other.

## Changes (backend `adempiere-grpc-server`, via patches)
- Add dependency `org.springframework.security:spring-security-crypto:6.5.7` (same `BCryptPasswordEncoder` as Sabana).
- **New provider `org.solop.secure.SecureBCrypt implements SecureInterface`**: BCrypt password hashing + dual verification (BCrypt **or** legacy SHA-512 + salt). Reversible encryption / digest / SHA-512 are delegated to the legacy `Secure` engine, so column encryption and already-encrypted data keep exactly the previous behavior.
- **`SecureInterface`** (override): new password methods with default legacy behavior — `getPasswordHash`, `isPasswordHashEncrypted`, `isValidPasswordHash(plain, hash, salt)` and a convenience `isValidPasswordHash(plain, hash)` overload. `ADEMPIERE_SECURE_DEFAULT` now points to `org.solop.secure.SecureBCrypt`, making BCrypt the default provider with no env/JVM flag (still overridable with `-DADEMPIERE_SECURE=…`).
- **`SecureEngine`** (override): static delegators for the new methods.
- **`MUser.setPassword`**: writes BCrypt when the SysConfig `USER_PASSWORD_HASH_BCRYPT` is enabled (default), otherwise the legacy SHA-512 + salt.
- **`Login.getAuthenticatedUserId`**: verifies both formats and lazily re-hashes a non-BCrypt password to BCrypt on a successful login (only when enabled and the column is not data-storage encrypted).

## Behavior & backward compatibility
- Verification always accepts BCrypt and legacy SHA-512 + salt → no user is locked out, and BCrypt hashes written by Sabana authenticate immediately.
- Plaintext legacy logins keep working (unchanged).
- SHA-512 users are migrated to BCrypt on their next successful login (a single write), then stay BCrypt.

## Configuration
- SysConfig **`USER_PASSWORD_HASH_BCRYPT`** (System level), **default ON**. Set `Value = N` on a specific database to keep writing SHA-512 (BCrypt verification still works either way).
- Requires `AD_User.Password` **without** data-storage encryption (`AD_Column.IsEncrypted = N`, the standard state). BCrypt hashing and column encryption on `Password` are mutually exclusive.

## Verification
- `./gradlew compileJava` — OK.
- Standalone harness against a development database:
  - **Crypto:** active provider = `SecureBCrypt`; BCrypt encode/verify; legacy SHA-512 verify; cross-parity with Sabana's `BCryptPasswordEncoder` in both directions — all pass.
  - **Real login (full ADempiere boot):** plaintext login; BCrypt write via `MUser.setPassword` (`$2` + `Salt` null); BCrypt login (correct / wrong); legacy SHA-512 login **and** lazy migration to BCrypt; re-login after migration — all pass (tested on a demo account with backup/restore).