### PR TITLE
fix: log full stack trace and sequence id in SequenceCheck.checkTableID catch

### DIFF
--- a/base/src/main/java/org/compiere/process/SequenceCheck.java
+++ b/base/src/main/java/org/compiere/process/SequenceCheck.java
@@ -274,7 +274,7 @@ public class SequenceCheck extends SvrProcess
 						}
 					}
 				} catch (Exception e) {
-					s_log.severe(e.getLocalizedMessage());
+					s_log.log(Level.SEVERE, "AD_Sequence_ID=" + sequenceId, e);
 				}
 			});
 		});


### PR DESCRIPTION
## Problem

In `SequenceCheck.checkTableID(...)`, the per-record `catch` inside the parallel lambda logged only the exception's localized message:

```java
} catch (Exception e) {
    s_log.severe(e.getLocalizedMessage());
}
```

This discards the **stack trace** and does not say **which sequence** failed, which is exactly what hid the original `NullPointerException` (`getCreated()` is null) — the log showed a bare message with no origin.

## Fix

Log the full exception with the failing sequence id:

```java
} catch (Exception e) {
    s_log.log(Level.SEVERE, "AD_Sequence_ID=" + sequenceId, e);
}
```

## How to test

1. Force an exception for one sequence during the **Sequence Check** process.
2. Before: a single-line message with no stack trace and no sequence reference.
3. After: `SEVERE` entry with `AD_Sequence_ID=<id>` and the full stack trace.

## Notes

- Diagnostics-only change; no functional behavior changes.
- `Level` is already imported; touches `SequenceCheck.java` only.
- Independent of the other SequenceCheck fixes (verified it auto-merges cleanly with the parallel-logging change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
