### PR TITLE
fix: Skip reservation locator lookup for manual movements

### DIFF
--- a/base/src/main/java/org/solop/util/ReservationBuilder.java
+++ b/base/src/main/java/org/solop/util/ReservationBuilder.java
@@ -171,8 +171,13 @@ public class ReservationBuilder {
                 reservation.setM_AttributeSetInstance_ID(movementLine.getM_AttributeSetInstance_ID());
                 reservation.setQty(movementLine.getMovementQty().negate());
             }
+            // Only resolve the locator for movement lines tied to a Distribution
+            // Order line. A manual movement (DD_OrderLine_ID = 0) has no reservation
+            // to build; calling fillLocatorLocatorId() here would throw
+            // "@M_Locator_ID@ @NotFound@" because warehouse/product stay unset.
+            // Mirrors withInOutLine, which gates fillLocatorLocatorId() the same way.
+            fillLocatorLocatorId();
         }
-        fillLocatorLocatorId();
         return this;
     }
 


### PR DESCRIPTION
## Summary
- Completing a manual inventory movement (M_Movement not linked to a Distribution Order) failed with "@M_Locator_ID@ @NotFound@" ("Ubicación * No encontrado *") during MMovement.completeIt. In ReservationBuilder.withMovementLine all reservation data (warehouse, product, locator, reservation type) is set inside `if (DD_OrderLine_ID > 0)`, but fillLocatorLocatorId() was called outside that gate; for a manual line (DD_OrderLine_ID = 0) the block is skipped, so the reservation stays empty and fillLocatorLocatorId() throws because warehouse/product are unset. A manual movement has no order to reserve against and should not build a reservation at all — build()'s isValid() already returns null there (ReservationType is never set), so the premature locator lookup was the only failing step. This moves fillLocatorLocatorId() inside the gate, mirroring withInOutLine.

## Changes
- `src/patches/java/org/solop/util/ReservationBuilder.java` — patch (shadows the adempiere-base class) that moves fillLocatorLocatorId() inside the `if (movementLine.getDD_OrderLine_ID() > 0)` block in withMovementLine, so manual movement lines skip locator resolution and create no reservation, consistent with withInOutLine.

## Test plan
- [x] Complete a manual inventory movement (Documento Manual, no Distribution Order) → completes without "Ubicación * No encontrado *"; no MReservation row created.
- [ ] Complete a movement generated from a Distribution Order → unchanged: the reservation is created as before.
- [x] `./gradlew compileJava` green.