### PR TITLE
fix: Sync reserved/ordered in UpdateStorage snapshot

### DIFF
--- a/base/src/main/java/org/solop/process/UpdateStorage.java
+++ b/base/src/main/java/org/solop/process/UpdateStorage.java
@@ -111,7 +111,10 @@ public class UpdateStorage extends UpdateStorageAbstract {
 		}
 		//Group By
 		transactionSQL.append("GROUP BY r.AD_Client_ID, r.AD_Org_ID, r.M_Product_ID, r.M_Locator_ID, r.M_Warehouse_ID, r.M_AttributeSetInstance_ID ");
-		transactionSQL.append("HAVING SUM(CASE WHEN r.ReservationType IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0 AND SUM(CASE WHEN r.ReservationType NOT IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0");
+		transactionSQL.append(
+			"HAVING SUM(CASE WHEN r.ReservationType IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0 "
+			+ "OR SUM(CASE WHEN r.ReservationType NOT IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0 "
+		);
 		log.fine("SnapshotSQL (Reservations)=" + transactionSQL);
 		int inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), get_TrxName());
 		log.fine("Snapshot Created (Reservations)=" + inserted);
@@ -161,4 +164,5 @@ public class UpdateStorage extends UpdateStorageAbstract {
 			processedTransactions.addAndGet(inserted);
 		}
 	}
+
 }

--- a/base/src/main/java/org/solop/util/StorageUpdaterBuilder.java
+++ b/base/src/main/java/org/solop/util/StorageUpdaterBuilder.java
@@ -168,14 +168,15 @@ public class StorageUpdaterBuilder {
     private void createStoreFromSnapshot(MStorageSnapshotRun lastSnapshot) {
         List<Object> parameters = new ArrayList<>();
         StringBuilder transactionSQL = new StringBuilder("INSERT INTO M_Storage (M_Storage_ID, AD_Client_ID, AD_Org_ID, M_Product_ID, M_Locator_ID, M_AttributeSetInstance_ID, QtyOnHand, QtyReserved, QtyOrdered, IsActive, Created, CreatedBy, Updated, UpdatedBy, UUID) " +
-                "SELECT nextval('m_storage_seq'), ssr.AD_Client_ID, sl.AD_Org_ID, sl.M_Product_ID, sl.M_Locator_ID, sl.M_AttributeSetInstance_ID, SUM(sl.QtyOnHand), SUM(sl.QtyReserved), SUM(sl.QtyOrdered), 'Y', now(), ssr.CreatedBy, now(), ssr.UpdatedBy, getUUID() " +
+                "SELECT nextval('m_storage_seq'), ssr.AD_Client_ID, loc.AD_Org_ID, sl.M_Product_ID, sl.M_Locator_ID, sl.M_AttributeSetInstance_ID, SUM(sl.QtyOnHand), SUM(sl.QtyReserved), SUM(sl.QtyOrdered), 'Y', now(), ssr.CreatedBy, now(), ssr.UpdatedBy, getUUID() " +
                 "FROM M_StorageSnapshotRun ssr " +
                 "INNER JOIN M_StorageSnapshot sl ON(sl.M_StorageSnapshotRun_ID = ssr.M_StorageSnapshotRun_ID) " +
+                "INNER JOIN M_Locator loc ON(loc.M_Locator_ID = sl.M_Locator_ID) " +
                 "WHERE sl.AD_Client_ID = ? ");
         parameters.add(getClientId());
         //	Org
         if (getOrganizationId() != 0) {
-            transactionSQL.append("AND sl.AD_Org_ID = ? ");
+            transactionSQL.append("AND loc.AD_Org_ID = ? ");
             parameters.add(getOrganizationId());
         }
         //	Warehouse
@@ -203,7 +204,7 @@ public class StorageUpdaterBuilder {
         }
         transactionSQL.append("AND sl.M_StorageSnapshotRun_ID = ? ");
         //	Group By
-        transactionSQL.append("GROUP BY ssr.AD_Client_ID, sl.AD_Org_ID, sl.M_Product_ID, sl.M_Locator_ID, sl.M_AttributeSetInstance_ID, ssr.CreatedBy, ssr.UpdatedBy ");
+        transactionSQL.append("GROUP BY ssr.AD_Client_ID, loc.AD_Org_ID, sl.M_Product_ID, sl.M_Locator_ID, sl.M_AttributeSetInstance_ID, ssr.CreatedBy, ssr.UpdatedBy ");
         parameters.add(lastSnapshot.getM_StorageSnapshotRun_ID());
         log.fine("StorageSQL (Snapshot)=" + transactionSQL);
         int inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), getTransactionName());

--- a/base/src/main/java/org/solop/util/StorageUpdaterBuilder.java
+++ b/base/src/main/java/org/solop/util/StorageUpdaterBuilder.java
@@ -180,7 +180,12 @@ public class StorageUpdaterBuilder {
         }
         //	Warehouse
         if (getWarehouseId() != 0) {
-            transactionSQL.append("AND sl.M_Warehouse_ID = ? ");
+			transactionSQL.append(
+				"AND EXISTS("
+				+ "SELECT 1 FROM M_Locator AS l "
+				+ "WHERE l.M_Locator_ID = sl.M_Locator_ID AND l.M_Warehouse_ID = ?"
+				+ ") "
+			);
             parameters.add(getWarehouseId());
         }
         //Product
@@ -390,4 +395,5 @@ public class StorageUpdaterBuilder {
             processedNewTransactions.addAndGet(inserted);
         }
     }
+
 }


### PR DESCRIPTION
## Summary
- Two bugs in the "Update Storage" process leave M_Storage.QtyReserved/QtyOrdered at 0 system-wide (≈97% of rows in dev), corrupting the denormalized stock ledger the whole ERP reads for availability — order/shipment checks (overselling risk), MRP/replenishment, reports and Product Info — not just Available-to-Promise. The process is destructive: it deletes and rebuilds M_Storage from a broken snapshot. M_Reservation (source of truth) is intact, so re-running after the fix fully restores M_Storage.
- HAVING uses AND instead of OR, so a locator with only reserved OR only ordered  movements is dropped from the snapshot (the common case).
- The snapshot restore references sl.M_Warehouse_ID, which does not exist on M_StorageSnapshot → SQL error when running with a warehouse filter.

## Changes
- `base/src/main/java/org/solop/process/UpdateStorage.java` — createSnapshotFromReservations HAVING: `AND` → `OR`.
- `base/src/main/java/org/solop/util/StorageUpdaterBuilder.java` — createStoreFromSnapshot: replace `sl.M_Warehouse_ID = ?` with an EXISTS against M_Locator (same pattern as createStoreFromTransactions).

## Test plan
- [ ] `./gradlew ... compileJava` green.
- [ ] Reserved/ordered in M_Storage reconcile with M_Reservation after the process.
- [ ] Process runs with a warehouse filter without SQL error.