### PR TITLE
perf: Add `M_Reservation` product index migration

### DIFF
--- a/resources/1.5.13/00503710_D_1_5_13_Add_M_Reservation_Product_Index.xml
+++ b/resources/1.5.13/00503710_D_1_5_13_Add_M_Reservation_Product_Index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add_M_Reservation_Product_Index" ReleaseNo="1.5.13" SeqNo="503710">
+    <Comments>Add index on M_Reservation.M_Product_ID to speed up per-product reservation lookups (Available-to-Promise detail and the Update Storage process), avoiding a full sequential scan of the reservation ledger. by EdwinBetanc0urt.</Comments>
+    <Step DBType="Postgres" Parse="Y" SeqNo="10" StepType="SQL">
+      <SQLStatement>CREATE INDEX IF NOT EXISTS idx_m_reservation_m_product_id ON M_Reservation (M_Product_ID);
+      </SQLStatement>
+      <RollbackStatement>DROP INDEX IF EXISTS idx_m_reservation_m_product_id;
+      </RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
## Summary
- Per-product reservation reads (the Available-to-Promise detail and the Update Storage process) do a full sequential scan of M_Reservation, because its only index is the primary key on M_Reservation_ID.
- Add an index on M_Reservation(M_Product_ID). Measured on dev (dyd-dev, 292k rows): a per-product aggregate drops from a 292k-row seq scan (~7,150 shared buffers, ~30 ms) to an index scan (~72 buffers, ~0.2 ms) — ~140x faster, and O(rows-per-product) instead of O(table), so it stays flat as the ledger grows.
- Complements the UpdateStorage reservation-sync fix; not required by it.

## Changes
- `resources/1.5.13/00503710_D_1_5_13_Add_M_Reservation_Product_Index.xml` — migration Step (StepType=SQL, Postgres): `CREATE INDEX IF NOT EXISTS idx_m_reservation_m_product_id ON M_Reservation (M_Product_ID)` with matching `DROP INDEX IF EXISTS` rollback.

## Test plan
- [ ] Run the migration → `idx_m_reservation_m_product_id` created (idempotent via IF NOT EXISTS).
- [ ] `EXPLAIN` a per-product M_Reservation aggregate → Index Scan, no longer Seq Scan.
- [ ] Rollback statement drops the index cleanly.