### PR TITLE
fix: Always set exp on third-party grant tokens

### DIFF
--- a/jwt/src/main/java/org/spin/eca52/security/JWT.java
+++ b/jwt/src/main/java/org/spin/eca52/security/JWT.java
@@ -54,6 +54,12 @@ public class JWT implements IThirdPartyAccessGenerator {
 	private String language;
 	/**	Session ID	*/
 	private int sessionId;
+	/**	SysConfig (ms): maximum lifetime for third party grant tokens; caps even a longer value set on the token definition	*/
+	private static final String ECA52_TOKEN_MAX_EXPIRE_TIME = "ECA52_TOKEN_MAX_EXPIRE_TIME";
+	/**	Default maximum grant-token lifetime: 90 days in ms	*/
+	private static final long DEFAULT_MAX_TOKEN_EXPIRE_MILLIS = 90L * 24 * 60 * 60 * 1000;
+	/**	Default grant-token lifetime when the definition expires but sets no explicit time: 5 min in ms	*/
+	private static final long DEFAULT_TOKEN_EXPIRE_MILLIS = 5L * 60 * 1000;
 
 	public JWT() {
     	//	
@@ -103,6 +109,29 @@ public class JWT implements IThirdPartyAccessGenerator {
 		);
 		SecretKey secretKey = Keys.hmacShaKeyFor(keyBytes);
 		return secretKey;
+	}
+
+	/**
+	 * Maximum lifetime (ms) allowed for a third party grant token. Read from SysConfig
+	 * {@code ECA52_TOKEN_MAX_EXPIRE_TIME} (per client); falls back to
+	 * {@link #DEFAULT_MAX_TOKEN_EXPIRE_MILLIS}. Guarantees a grant token can never be
+	 * minted without an expiration nor with an unbounded one.
+	 * @param clientId current client
+	 * @return maximum lifetime in milliseconds (always &gt; 0)
+	 */
+	private static long getMaxTokenExpireMillis(int clientId) {
+		String value = MSysConfig.getValue(ECA52_TOKEN_MAX_EXPIRE_TIME, clientId);
+		if(!Util.isEmpty(value, true)) {
+			try {
+				long parsed = Long.parseLong(value.trim());
+				if(parsed > 0) {
+					return parsed;
+				}
+			} catch (NumberFormatException e) {
+				//	fall through to default
+			}
+		}
+		return DEFAULT_MAX_TOKEN_EXPIRE_MILLIS;
 	}
 
 
@@ -170,21 +199,32 @@ public class JWT implements IThirdPartyAccessGenerator {
 			.signWith(secretKey, Jwts.SIG.HS256)
 		;
 
-		//	Validate
+		//	Grant tokens must always carry an exp claim and never exceed a maximum lifetime,
+		//	so a third party token can never be valid forever (previously no exp when IsHasExpireDate='N').
+		long maxExpireMillis = getMaxTokenExpireMillis(clientId);
+		long requestedMillis;
 		if(definition.isHasExpireDate()) {
-			BigDecimal expirationTime = Optional.ofNullable(
+			requestedMillis = Optional.ofNullable(
 					definition.getExpirationTime()
 				).orElse(
-					new BigDecimal(5 * 60 * 1000)
-				)
+					new BigDecimal(DEFAULT_TOKEN_EXPIRE_MILLIS)
+				).longValue()
 			;
-			token.setExpireDate(
-				new Timestamp(currentTimeMillis + expirationTime.longValue())
-			);
-			jwtBuilder.expiration(
-				new Date(currentTimeMillis + expirationTime.longValue())
-			);
+		} else {
+			//	Previously non-expiring: fall back to the maximum cap.
+			requestedMillis = maxExpireMillis;
 		}
+		//	Clamp to the cap; guard against non-positive values.
+		long effectiveMillis = requestedMillis <= 0
+			? maxExpireMillis
+			: Math.min(requestedMillis, maxExpireMillis)
+		;
+		token.setExpireDate(
+			new Timestamp(currentTimeMillis + effectiveMillis)
+		);
+		jwtBuilder.expiration(
+			new Date(currentTimeMillis + effectiveMillis)
+		);
 		userTokenValue = jwtBuilder.compact();
 		String tokenValue = null;
 		try {

--- a/jwt/xml/migration/10340_ECA52_Add_SysConfig_Token_Max_Expire.xml
+++ b/jwt/xml/migration/10340_ECA52_Add_SysConfig_Token_Max_Expire.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="ECA52" Name="ECA52 Add SysConfig Token Max Expire" ReleaseNo="1.0" SeqNo="10340">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="50009" Action="I" Record_ID="50182" Table="AD_SysConfig">
+        <Data AD_Column_ID="50196" Column="Value">7776000000</Data>
+        <Data AD_Column_ID="84421" Column="UUID">815ddeb6-e2ca-47ff-85a1-a3fa92c5b2d4</Data>
+        <Data AD_Column_ID="50193" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="50191" Column="Updated">2026-07-22 15:20:00.0</Data>
+        <Data AD_Column_ID="50195" Column="Name">ECA52_TOKEN_MAX_EXPIRE_TIME</Data>
+        <Data AD_Column_ID="50194" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53270" Column="EntityType">ECA52</Data>
+        <Data AD_Column_ID="50197" Column="Description">Maximum lifetime, in milliseconds, allowed for an ECA52 third party grant token. Every grant token always carries an exp claim and its effective time to live is min(requested, this cap); when the token definition has no expire date it falls back to this value instead of never expiring. Default 7776000000 ms (90 days). Set 0 or leave empty to use the built-in default.</Data>
+        <Data AD_Column_ID="50192" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="50190" Column="Created">2026-07-22 15:20:00.0</Data>
+        <Data AD_Column_ID="53271" Column="ConfigurationLevel">S</Data>
+        <Data AD_Column_ID="50187" Column="AD_SysConfig_ID">50182</Data>
+        <Data AD_Column_ID="50189" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="50188" Column="AD_Client_ID">0</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
fix: Always set exp on third-party grant tokens

## Summary
- ECA52 third-party grant tokens only carried an `exp` claim when the token definition had `IsHasExpireDate='Y'`; with `'N'` they were minted without `exp` and stayed valid forever. Now every grant token always carries `exp`, and its lifetime is capped so it can never exceed a configurable maximum.

## Changes
- `jwt/src/main/java/org/spin/eca52/security/JWT.java` — `generateToken` always sets `exp`. Effective TTL = min(requested, cap); when the definition has no expire date it falls back to the cap instead of no expiration. New SysConfig `ECA52_TOKEN_MAX_EXPIRE_TIME` (milliseconds, per client) sets the cap, default 90 days.
- `jwt/xml/migration/10340_ECA52_Add_SysConfig_Token_Max_Expire.xml` — migration that inserts the `ECA52_TOKEN_MAX_EXPIRE_TIME` System Configurator record (System level, default `7776000000` ms = 90 days).

## Test plan
- [ ] Grant token from a definition with `IsHasExpireDate='N'` now carries an `exp` (~90d or the configured cap)
- [ ] Grant token with a shorter configured expire time keeps that time
- [ ] A definition whose expire time exceeds the cap is clamped to the cap
- [ ] Session / local JWT issuance is unaffected
