### PR TITLE
fix: Commit imported references before column sync.

### DIFF
--- a/base/src/main/java/org/adempiere/pipo/PackInHandler.java
+++ b/base/src/main/java/org/adempiere/pipo/PackInHandler.java
@@ -588,6 +588,15 @@ public class PackInHandler extends DefaultHandler {
         	//	
         	//	Columns
         	if(Env.getContext(context, "SynchronizeColumns").equals("Y") && columns.size() > 0) {
+				// Commit the dictionary rows imported in this transaction (AD_Reference, AD_Ref_Table, AD_Val_Rule, ...)
+				// BEFORE synchronizing the columns. MColumn.syncDatabase() -> DisplayType.getSQLDataType() -> MRefTable.getById()
+				// reads AD_Ref_Table with trxName = null, so a reference-value column whose AD_Ref_Table was imported in
+				// this same (still open) transaction would resolve to null and be created as VARCHAR instead of NUMERIC.
+				// Committing here makes the just-imported references visible to that lookup.
+				Trx syncTrx = Trx.get(trxName, false);
+				if (syncTrx != null && !syncTrx.commit()) {
+					log.warning("Could not commit imported references before column sync; reference-value column types may not resolve");
+				}
         		for (Element e : columns) {
     	    		Attributes atts = e.attributes;
     	    		String columnUuid = atts.getValue(AttributeFiller.getUUIDAttribute(I_AD_Column.Table_Name));


### PR DESCRIPTION
Prevent 2Pack reference-value columns from being created as `VARCHAR` instead of `NUMERIC`

## Summary
- During a 2Pack import, a reference-value column (`Table`/`Search`/`TableDir`/`List` with an `AD_Reference_Value_ID`) whose `AD_Ref_Table` is bundled in the same package could be physically created as `VARCHAR` instead of `NUMERIC`. The deferred column sync runs inside the still-open import transaction, and `MColumn.syncDatabase()` -> `DisplayType.getSQLDataType()` -> `MRefTable.getById()` reads `AD_Ref_Table` with `trxName = null`; the just-imported (uncommitted) reference is therefore invisible and resolves to null, so the physical type is not derived from the referenced key column. This commits the import transaction right before the deferred column sync so those references are visible and the column type resolves correctly.

## Changes
- `base/src/main/java/org/adempiere/pipo/PackInHandler.java` — commit the import transaction before the deferred column-sync loop in `endElement()`, so `MRefTable.getById()` (which reads with `trxName = null`) sees the `AD_Reference`/`AD_Ref_Table` rows imported earlier in the same transaction. This complements the type-resolution fix in `DisplayType.getSQLDataType()` and also covers reference-value columns whose name does not end in `_ID`.

## Test plan
- [ ] Import a 2Pack that creates a new column with a `Table`/`Search` reference whose `AD_Ref_Table` is bundled in the same package; verify the physical column is `NUMERIC(10)`, not `VARCHAR`.
- [ ] Re-import an existing package; verify column synchronization has no regression and no spurious "Unhandled Data Type" warnings.
- [x] `./gradlew build` green.