### PR TITLE
fix: Block allocations mixing business partners

### DIFF
--- a/base/src/main/java/org/compiere/model/MAllocationHdr.java
+++ b/base/src/main/java/org/compiere/model/MAllocationHdr.java
@@ -540,14 +540,10 @@ public final class MAllocationHdr extends X_C_AllocationHdr implements DocAction
 	 * 	Gather the Business Partners for each document referenced by the lines (payment, invoice, order);
 	 * 	if more than one appears, abort the document. Reversals are exempt (see prepareIt),
 	 * 	in order that already corrupted allocations can be reversed/cancelled.
-	 * 	Configurable via the SysConfig VALIDATE_ALLOCATION_SINGLE_BPARTNER (default: Y).
 	 * 	@param allocationLines allocation lines
 	 */
 	private void validateSingleBusinessPartner(List<MAllocationLine> allocationLines)
 	{
-		if (!MSysConfig.getBooleanValue("VALIDATE_ALLOCATION_SINGLE_BPARTNER", true, getAD_Client_ID())) {
-			return;
-		}
 		//	Business Partner -> document where it first appeared (for the message details)
 		Map<Integer, String> businessPartners = new LinkedHashMap<Integer, String>();
 		for (MAllocationLine allocationLine : allocationLines) {

--- a/base/src/main/java/org/compiere/model/MAllocationHdr.java
+++ b/base/src/main/java/org/compiere/model/MAllocationHdr.java
@@ -41,7 +41,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -485,6 +487,11 @@ public final class MAllocationHdr extends X_C_AllocationHdr implements DocAction
 					});
 		}
 
+		//	Prevent an assignment from mixing different business partners (exempt reversals)
+		if (!isReversal()) {
+			validateSingleBusinessPartner(allocationLines);
+		}
+
 		//	Add up Amounts & validate
 		AtomicReference<BigDecimal> approval = new AtomicReference<>(Env.ZERO);
 		allocationLines.stream()
@@ -527,6 +534,61 @@ public final class MAllocationHdr extends X_C_AllocationHdr implements DocAction
 		
 		return DocAction.STATUS_InProgress;
 	}	//	prepareIt
+
+	/**
+	 * 	Prevent an assignment from mixing different business partners.
+	 * 	Gather the Business Partners for each document referenced by the lines (payment, invoice, order);
+	 * 	if more than one appears, abort the document. Reversals are exempt (see prepareIt),
+	 * 	in order that already corrupted allocations can be reversed/cancelled.
+	 * 	Configurable via the SysConfig VALIDATE_ALLOCATION_SINGLE_BPARTNER (default: Y).
+	 * 	@param allocationLines allocation lines
+	 */
+	private void validateSingleBusinessPartner(List<MAllocationLine> allocationLines)
+	{
+		if (!MSysConfig.getBooleanValue("VALIDATE_ALLOCATION_SINGLE_BPARTNER", true, getAD_Client_ID())) {
+			return;
+		}
+		//	Business Partner -> document where it first appeared (for the message details)
+		Map<Integer, String> businessPartners = new LinkedHashMap<Integer, String>();
+		for (MAllocationLine allocationLine : allocationLines) {
+			if (allocationLine.getC_Payment_ID() > 0) {
+				MPayment payment = new MPayment(getCtx(), allocationLine.getC_Payment_ID(), get_TrxName());
+				addBusinessPartnerReference(businessPartners, payment.getC_BPartner_ID(), "@C_Payment_ID@ " + payment.getDocumentNo());
+			}
+			if (allocationLine.getC_Invoice_ID() > 0) {
+				MInvoice invoice = new MInvoice(getCtx(), allocationLine.getC_Invoice_ID(), get_TrxName());
+				addBusinessPartnerReference(businessPartners, invoice.getC_BPartner_ID(), "@C_Invoice_ID@ " + invoice.getDocumentNo());
+			}
+			if (allocationLine.getC_Order_ID() > 0) {
+				MOrder order = new MOrder(getCtx(), allocationLine.getC_Order_ID(), get_TrxName());
+				addBusinessPartnerReference(businessPartners, order.getC_BPartner_ID(), "@C_Order_ID@ " + order.getDocumentNo());
+			}
+		}
+		if (businessPartners.size() > 1) {
+			StringBuilder detail = new StringBuilder();
+			for (Map.Entry<Integer, String> reference : businessPartners.entrySet()) {
+				if (detail.length() > 0) {
+					detail.append(" | ");
+				}
+				detail.append(MBPartner.get(getCtx(), reference.getKey()).getName())
+					.append(" (").append(Msg.parseTranslation(getCtx(), reference.getValue())).append(")");
+			}
+			processMsg = Msg.parseTranslation(getCtx(), "@MixedBPartnerAllocation@") + ": " + detail;
+			throw new AdempiereException(processMsg);
+		}
+	}	//	validateSingleBusinessPartner
+
+	/**
+	 * 	Record the Business Partner and the document where it first appeared.
+	 * 	@param businessPartners Business Partner accumulator -> source document
+	 * 	@param businessPartnerId Business Partner ID to register (ignores 0)
+	 * 	@param source reference of the document (@C_Payment_ID@, @C_Invoice_ID@, ...)
+	 */
+	private void addBusinessPartnerReference(Map<Integer, String> businessPartners, int businessPartnerId, String source)
+	{
+		if (businessPartnerId > 0 && !businessPartners.containsKey(businessPartnerId))
+			businessPartners.put(businessPartnerId, source);
+	}	//	addBusinessPartnerReference
 	
 	/**
 	 * 	Approve Document

--- a/resources/1.5.14/00503830_D_1_5_14_Add_Message_MixedBPartnerAllocation.xml
+++ b/resources/1.5.14/00503830_D_1_5_14_Add_Message_MixedBPartnerAllocation.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add_Message_MixedBPartnerAllocation" ReleaseNo="1.5.14" SeqNo="503830">
+    <Comments>Add error message for allocations mixing different business partners. By EdwinBetanc0urt.</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53853" Table="AD_Message">
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53853</Data>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="589" Column="Created">2026-07-24 00:00:00.0</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="198" Column="MsgText">The allocation cannot be completed because it involves more than one business partner.</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="197" Column="MsgType">E</Data>
+        <Data AD_Column_ID="591" Column="Updated">2026-07-24 00:00:00.0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID">b015d716-a3cf-438a-97ef-11387106b942</Data>
+        <Data AD_Column_ID="6766" Column="Value">MixedBPartnerAllocation</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53853</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="609" Column="Created">2026-07-24 00:00:00.0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">The allocation cannot be completed because it involves more than one business partner.</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="611" Column="Updated">2026-07-24 00:00:00.0</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID">380bdc6f-bc36-41fe-bb1d-9889bcce0f9b</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53853">53853</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="The allocation cannot be completed because it involves more than one business partner.">La asignación no puede completarse porque involucra más de un socio de negocio.</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
## Summary
- A payment allocation (`C_AllocationHdr`) could be completed while linking documents that belong to different business partners (for example a payment of partner A allocated against invoices of partner B). This silently corrupts open balances and account statements for both partners. This adds a guard that blocks completion when a single allocation involves more than one business partner.
- Depends on two dictionary entries shipped in a separate migration: the `AD_Message` `SP_MixedBPartnerAllocation` (error text) and the `SysConfig` `VALIDATE_ALLOCATION_SINGLE_BPARTNER` (default `Y`). The code defaults to enabled even if the SysConfig row is absent.

## Changes
- `base/src/main/java/org/compiere/model/MAllocationHdr.java` — in `prepareIt()`, for non-reversal documents, gather the business partner of every document referenced by the lines (payment, invoice, order) and throw an `AdempiereException` when more than one distinct partner is involved, listing the conflicting partners. Reversals are exempt so previously created allocations can still be reversed/voided. Guarded by the `VALIDATE_ALLOCATION_SINGLE_BPARTNER` SysConfig.

## Test plan
- [ ] Happy path: allocate a payment to invoices of the same partner → completes normally.
- [ ] Guard: allocate a payment to invoices of two different partners → completion blocked with a message listing the partners.
- [ ] Reversal: void/reverse an existing mixed-partner allocation → allowed (not blocked).
- [ ] Toggle: `VALIDATE_ALLOCATION_SINGLE_BPARTNER = N` → guard disabled.
- [ ] `./gradlew build` green.