### PR TITLE
fix: Capture tab-context prefix in column names

### DIFF
--- a/kafka/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java
+++ b/kafka/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java
@@ -19,7 +19,6 @@ package org.spin.eca56.util.support.documents;
 
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,18 +111,34 @@ public class ReferenceUtil {
 
 
 	public static String joinStrings(String... stringValues) {
-		// StringBuilder stringBuilder = new StringBuilder();
-		// for (String stringValue : stringValues) {
-		// 	if (!Util.isEmpty(stringValue, true)) {
-		// 		stringBuilder.append(stringValue);
-		// 	}
-		// }
-		// return stringBuilder.toString();
-		return String.join(
-			"",
-			Arrays.stream(stringValues)
-				.filter(s -> !Util.isEmpty(s, true))
-				.toArray(String[]::new)
+		StringBuilder stringBuilder = new StringBuilder();
+		for (String stringValue : stringValues) {
+			if (!Util.isEmpty(stringValue, true)) {
+				stringBuilder.append(stringValue);
+			}
+		}
+		return stringBuilder.toString();
+		// return String.join(
+		// 	"",
+		// 	Arrays.stream(stringValues)
+		// 		.filter(s -> !Util.isEmpty(s, true))
+		// 		.toArray(String[]::new)
+		// );
+	}
+
+	/**
+	 * Varargs overload: extract context column names from several context strings.
+	 * Kept alongside getContextColumnNames(String) so callers compiled against the single-argument
+	 * signature (Window/Browser/Process/ReferenceValues in the jar) keep linking (binary compatibility).
+	 * @param values context strings
+	 * @return List<String>
+	 */
+	public static List<String> getContextColumnNames(String... values) {
+		if (values == null || values.length <= 0) {
+			return new ArrayList<String>();
+		}
+		return getContextColumnNames(
+			joinStrings(values)
 		);
 	}
 
@@ -133,11 +148,7 @@ public class ReferenceUtil {
 	 * @return
 	 * @return List<String>
 	 */
-	public static List<String> getContextColumnNames(String... values) {
-		if (values == null || values.length <= 0) {
-			return new ArrayList<String>();
-		}
-		String context = joinStrings(values);
+	public static List<String> getContextColumnNames(String context) {
 		if (Util.isEmpty(context, true)) {
 			return new ArrayList<String>();
 		}

--- a/kafka/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java
+++ b/kafka/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java
@@ -19,6 +19,7 @@ package org.spin.eca56.util.support.documents;
 
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,13 +110,34 @@ public class ReferenceUtil {
 		return newDisplayType;
 	}
 
+
+	public static String joinStrings(String... stringValues) {
+		// StringBuilder stringBuilder = new StringBuilder();
+		// for (String stringValue : stringValues) {
+		// 	if (!Util.isEmpty(stringValue, true)) {
+		// 		stringBuilder.append(stringValue);
+		// 	}
+		// }
+		// return stringBuilder.toString();
+		return String.join(
+			"",
+			Arrays.stream(stringValues)
+				.filter(s -> !Util.isEmpty(s, true))
+				.toArray(String[]::new)
+		);
+	}
+
 	/**
 	 * Get Context column names from context
 	 * @param context
 	 * @return
 	 * @return List<String>
 	 */
-	public static List<String> getContextColumnNames(String context) {
+	public static List<String> getContextColumnNames(String... values) {
+		if (values == null || values.length <= 0) {
+			return new ArrayList<String>();
+		}
+		String context = joinStrings(values);
 		if (Util.isEmpty(context, true)) {
 			return new ArrayList<String>();
 		}
@@ -123,7 +145,9 @@ public class ReferenceUtil {
 		String END   = "\\@";  // A literal ")" character in regex
 
 		// Captures the word(s) between the above two character(s)
-		final String COLUMN_NAME_PATTERN = START + "(#|$|\\d\\|){0,1}(\\w+)" + END;
+		// support the two-char tab-context prefix `\d+\|` (e.g. `@0|C_BPartner_ID@`);
+		// the previous single-char class only matched one char, so tab-context columns were never captured.
+		final String COLUMN_NAME_PATTERN = START + "(#|$|\\d+\\||\\|){0,1}(\\w+)" + END;
 
 		Pattern pattern = Pattern.compile(
 			COLUMN_NAME_PATTERN,
@@ -132,7 +156,12 @@ public class ReferenceUtil {
 		Matcher matcher = pattern.matcher(context);
 		Map<String, Boolean> columnNamesMap = new HashMap<String, Boolean>();
 		while(matcher.find()) {
-			final String columnContext = matcher.group().replace("@", "").replace("@", "");
+			// strip the tab-context prefix (`0|C_BPartner_ID` -> `C_BPartner_ID`) so the bare
+			// column name is advertised to the frontend and its value is sent back on lookups/browsers.
+			final String columnContext = matcher.group()
+				.replace("@", "")
+				.replaceFirst("^\\d+\\|", "")
+			;
 			columnNamesMap.put(columnContext, true);
 		}
 		return new ArrayList<String>(columnNamesMap.keySet());


### PR DESCRIPTION
## Summary
- `getContextColumnNames()` extracts the context columns referenced by a field's validation/default logic so consumers know which values are required. Its regex only matched a single-character prefix, so the two-character tab-context prefix `N|` (e.g. `@0|C_BPartner_ID@`) was never matched and those columns were never reported. As a consequence, tab-context filters (business partner, currency, direction, ...) silently dropped and lookups/browsers could return records outside the intended scope. This captures `@N|Column@` references and returns the bare column name.

## Changes
- `kafka/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java` — widen the prefix group from `(#|$|\d\|)` to `(#|$|\d+\||\|)` so the two-char tab prefix matches; strip the leading `N|` from the captured token so the bare column name is returned. Accept varargs (`String...`) and join non-empty values, consistent with the shared context helper.

## Test plan
- [ ] `@0|C_BPartner_ID@` now yields `C_BPartner_ID` (previously empty); `@1|M_Warehouse_ID@` yields `M_Warehouse_ID`.
- [ ] `@#AD_Client_ID@` and `@C_BPartner_ID@` remain unchanged.
- [ ] `./gradlew build` green.