### PR TITLE
fix: Pass original value instead of displayedValue to NumberManager i…

### DIFF
--- a/grpc_utils/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
+++ b/grpc_utils/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
@@ -640,7 +640,7 @@ public class ValueManager {
 				);
 			} else {
 				displayedValue = NumberManager.getDisplayValue(
-					displayedValue,
+					value,
 					displayTypeId
 				);
 			}


### PR DESCRIPTION
…n numeric reference handling

Cuerpo:
fix: Correct numeric display value reference in ValueManager

## Summary
- Fix incorrect parameter passed to NumberManager.getDisplayValue() in the numeric display type branch of getDisplayedValueFromReference(); the method was passing the already-formatted displayedValue instead of the original value object, causing incorrect display formatting when rendering numeric fields with reference types.

## Changes
- `grpc_utils/src/main/java/org/spin/service/grpc/util/value/ValueManager.java` (line 643) — corrected parameter from `displayedValue` to `value` when invoking NumberManager.getDisplayValue()

## Test plan
- [ ] Numeric reference fields display correctly when using getDisplayedValueFromReference()
- [ ] Non-ProcessedOn numeric types (Account, Quantity, etc.) show proper formatted values
- [ ] ProcessedOn field continues to show elapsed time format
- [ ] Build succeeds (`./gradlew clean build`)