### PR TITLE
fix: Disable logging for high-frequency BPartner columns

### DIFF
--- a/resources/1.5.14/00503890_D_1_5_14_BPartner_Disable_Logging_High_Frequency_Columns.xml
+++ b/resources/1.5.14/00503890_D_1_5_14_BPartner_Disable_Logging_High_Frequency_Columns.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
   <Migration EntityType="D" Name="BPartner_Disable_Logging_High_Frequency_Columns" ReleaseNo="1.5.14" SeqNo="503890">
-    <Comments>Disable change log (IsAllowLogging) for C_BPartner columns that are recalculated on every Sales Order (ActualLifeTimeValue, SO_CreditUsed), following the same criterion already applied to TotalOpenBalance. Prevents the change log from growing unbounded on Business Partners used as POS default.</Comments>
+    <Comments>Disable change log (IsAllowLogging) for C_BPartner columns that are recalculated on every Sales Order (ActualLifeTimeValue, SO_CreditUsed, TotalOpenBalance). Prevents the change log from growing unbounded on Business Partners used as POS default.</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="112" Action="U" Record_ID="2925" Table="AD_Column">
         <Data AD_Column_ID="56187" Column="IsAllowLogging" oldValue="true">false</Data>
@@ -9,6 +9,11 @@
     </Step>
     <Step SeqNo="20" StepType="AD">
       <PO AD_Table_ID="112" Action="U" Record_ID="2921" Table="AD_Column">
+        <Data AD_Column_ID="56187" Column="IsAllowLogging" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="112" Action="U" Record_ID="12533" Table="AD_Column">
         <Data AD_Column_ID="56187" Column="IsAllowLogging" oldValue="true">false</Data>
       </PO>
     </Step>

--- a/resources/1.5.14/00503890_D_1_5_14_BPartner_Disable_Logging_High_Frequency_Columns.xml
+++ b/resources/1.5.14/00503890_D_1_5_14_BPartner_Disable_Logging_High_Frequency_Columns.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="BPartner_Disable_Logging_High_Frequency_Columns" ReleaseNo="1.5.14" SeqNo="503890">
+    <Comments>Disable change log (IsAllowLogging) for C_BPartner columns that are recalculated on every Sales Order (ActualLifeTimeValue, SO_CreditUsed), following the same criterion already applied to TotalOpenBalance. Prevents the change log from growing unbounded on Business Partners used as POS default.</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="112" Action="U" Record_ID="2925" Table="AD_Column">
+        <Data AD_Column_ID="56187" Column="IsAllowLogging" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="112" Action="U" Record_ID="2921" Table="AD_Column">
+        <Data AD_Column_ID="56187" Column="IsAllowLogging" oldValue="true">false</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
## Summary
- `ActualLifeTimeValue`, `TotalOpenBalance` and `SO_CreditUsed` on C_BPartner are recalculated on every Sales Order, and with `IsAllowLogging`=`Y` this filled AD_ChangeLog for high-traffic Business Partners (e.g. the default POS partner), making /api/logs/entities time out the browser; this applies the same `IsAllowLogging`=`N` criterion already in place for TotalOpenBalance.

## Changes
- `xml/migration/1.5.14/00503890_D_1_5_14_BPartner_Disable_Logging_High_Frequency_Columns.xml` — sets IsAllowLogging=N on AD_Column for C_BPartner.ActualLifeTimeValue (AD_Column_ID=2925) and C_BPartner.SO_CreditUsed (AD_Column_ID=2921); IsAllowCopy was already N on both, so it was left untouched.

## Test plan
- [ ] Apply migration against a test database and confirm AD_Column.IsAllowLogging = 'N' for both columns
- [ ] Trigger a Sales Order recalculation on a Business Partner and confirm no new AD_ChangeLog rows are created for these two columns
- [ ] Confirm rollback path restores IsAllowLogging = 'Y'