### PR TITLE
fix: Use first BPartner address, not last

### DIFF
--- a/base/src/main/java/org/compiere/model/MInOut.java
+++ b/base/src/main/java/org/compiere/model/MInOut.java
@@ -865,15 +865,18 @@ public class MInOut extends X_M_InOut implements DocAction , DocumentReversalEna
 		{
 			for (int i = 0; i < locs.length; i++)
 			{
-				if (locs[i].isShipTo())
+				if (getC_BPartner_Location_ID() <= 0 && locs[i].isShipTo()) {
 					setC_BPartner_Location_ID(locs[i].getC_BPartner_Location_ID());
+				}
 			}
 			//	set to first if not set
-			if (getC_BPartner_Location_ID() == 0 && locs.length > 0)
+			if (getC_BPartner_Location_ID() <= 0 && locs.length > 0) {
 				setC_BPartner_Location_ID(locs[0].getC_BPartner_Location_ID());
+			}
 		}
-		if (getC_BPartner_Location_ID() == 0)
+		if (getC_BPartner_Location_ID() <= 0) {
 			log.log(Level.SEVERE, "Has no To Address: " + bp);
+		}
 
 		//	Set Contact
 		MUser[] contacts = bp.getContacts(false);

--- a/base/src/main/java/org/compiere/model/MInvoice.java
+++ b/base/src/main/java/org/compiere/model/MInvoice.java
@@ -433,23 +433,26 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 		if (ss != null)
 			setPaymentRule(ss);
 
-
 		//	Set Locations
 		MBPartnerLocation[] locs = bp.getLocations(false);
 		if (locs != null)
 		{
 			for (int i = 0; i < locs.length; i++)
 			{
-				if ((locs[i].isBillTo() && isSOTrx())
-				|| (locs[i].isPayFrom() && !isSOTrx()))
+				if (getC_BPartner_Location_ID() <= 0
+					&& ((locs[i].isBillTo() && isSOTrx())
+					|| (locs[i].isPayFrom() && !isSOTrx()))) {
 					setC_BPartner_Location_ID(locs[i].getC_BPartner_Location_ID());
+				}
 			}
 			//	set to first
-			if (getC_BPartner_Location_ID() == 0 && locs.length > 0)
+			if (getC_BPartner_Location_ID() <= 0 && locs.length > 0) {
 				setC_BPartner_Location_ID(locs[0].getC_BPartner_Location_ID());
+			}
 		}
-		if (getC_BPartner_Location_ID() == 0)
+		if (getC_BPartner_Location_ID() <= 0) {
 			log.log(Level.SEVERE, new BPartnerNoAddressException(bp).getLocalizedMessage()); //TODO: throw exception?
+		}
 
 		//	Set Contact
 		MUser[] contacts = bp.getContacts(false);

--- a/base/src/main/java/org/compiere/model/MOrder.java
+++ b/base/src/main/java/org/compiere/model/MOrder.java
@@ -491,32 +491,34 @@ public class MOrder extends X_C_Order implements DocAction
 		
 		//	Discount
 		setIsDiscountPrinted(bp.isDiscountPrinted());
+
 		//	Set Locations
 		MBPartnerLocation[] locs = bp.getLocations(false);
 		if (locs != null)
 		{
 			for (int i = 0; i < locs.length; i++)
 			{
-				if (locs[i].isShipTo())
+				if (getC_BPartner_Location_ID() <= 0 && locs[i].isShipTo()) {
 					super.setC_BPartner_Location_ID(locs[i].getC_BPartner_Location_ID());
-				if (locs[i].isBillTo())
+				}
+				if (getBill_Location_ID() <= 0 && locs[i].isBillTo()) {
 					setBill_Location_ID(locs[i].getC_BPartner_Location_ID());
+				}
 			}
 			//	set to first
-			if (getC_BPartner_Location_ID() == 0 && locs.length > 0)
+			if (getC_BPartner_Location_ID() <= 0 && locs.length > 0) {
 				super.setC_BPartner_Location_ID(locs[0].getC_BPartner_Location_ID());
-			if (getBill_Location_ID() == 0 && locs.length > 0)
+			}
+			if (getBill_Location_ID() <= 0 && locs.length > 0) {
 				setBill_Location_ID(locs[0].getC_BPartner_Location_ID());
+			}
 		}
-		if (getC_BPartner_Location_ID() == 0)
-		{	
+		if (getC_BPartner_Location_ID() <= 0) {
 			throw new BPartnerNoShipToAddressException(bp);
-		}	
-			
-		if (getBill_Location_ID() == 0)
-		{
+		}
+		if (getBill_Location_ID() <= 0) {
 			throw new BPartnerNoBillToAddressException(bp);
-		}	
+		}
 
 		//	Set Contact
 		MUser[] contacts = bp.getContacts(false);


### PR DESCRIPTION
## Summary
- `setBPartner()` picked the last matching ship-to/bill-to `C_BPartner_Location` instead of the first, so a new address added later to a BPartner with an existing default silently overrode it in Orders, Shipments and Invoices.

## Changes
- `base/src/main/java/org/compiere/model/MOrder.java` — stop overwriting `C_BPartner_Location_ID`/`Bill_Location_ID` once a match is already set.
- `base/src/main/java/org/compiere/model/MInOut.java` — same fix for ship-to location.
- `base/src/main/java/org/compiere/model/MInvoice.java` — same fix for bill-to/pay-from location.

## Test plan
- [ ] BPartner with a single ship-to/bill-to address still resolves correctly (no regression).
- [ ] BPartner with multiple addresses flagged as ship-to/bill-to keeps the first one instead of the most recently created.
- [ ] Intercompany counter-document generation (`MOrder.createCounterDoc`) keeps using the original address after a new duplicate-flagged address is added to the shared BPartner.
- [ ] `./gradlew :base:compileJava` build green.