### PR TITLE
feat: block payment reversal referenced by an open bank statement line

### DIFF
--- a/base/src/main/java/org/compiere/model/MPayment.java
+++ b/base/src/main/java/org/compiere/model/MPayment.java
@@ -213,6 +213,21 @@ public final class MPayment extends X_C_Payment
 	}
 
 	/**
+	 * Get the bank statement line that references this payment on a bank
+	 * statement that is not yet completed or closed (still open reconciliation).
+	 * @return line or null
+	 */
+	private MBankStatementLine getOpenBankStatementLine() {
+		return new Query(getCtx(), I_C_BankStatementLine.Table_Name,
+				"C_Payment_ID = ? "
+				+ "AND EXISTS(SELECT 1 FROM C_BankStatement bs "
+				+ "		WHERE bs.C_BankStatement_ID = C_BankStatementLine.C_BankStatement_ID "
+				+ "		AND bs.DocStatus NOT IN('CO', 'CL', 'VO', 'RE'))", get_TrxName())
+				.setParameters(getC_Payment_ID())
+				.first();
+	}
+
+	/**
 	 *  Load Constructor
 	 *  @param ctx context
 	 *  @param rs result set record
@@ -2274,6 +2289,13 @@ public final class MPayment extends X_C_Payment
 
 	public MPayment reverseIt(boolean isAccrual)
 	{
+		MBankStatementLine openBankStatementLine = getOpenBankStatementLine();
+		if (openBankStatementLine != null) {
+			processMsg = Msg.getMsg(getCtx(), "Payment.ExistBankStatement",
+					new Object[] { openBankStatementLine.getParent().getDocumentNo(), openBankStatementLine.getLine() });
+			return null;
+		}
+
 		if (!voidOnlinePayment())
 			return null;
 


### PR DESCRIPTION
## Summary

Block reversing a payment while it is still referenced by an **open** (not yet completed or closed) bank statement line, so an in-progress reconciliation is not silently broken.

## Change

`MPayment.reverseIt(boolean)` now validates, before any reversal side effect, whether a `C_BankStatementLine` references this payment on a bank statement whose `DocStatus` is not in `CO`, `CL`, `VO`, `RE`. If such a line exists, the reversal aborts and surfaces the message `Payment.ExistBankStatement`, reporting the bank statement document number and the specific line number so the user can either remove the payment reference from that reconciliation line or complete the reconciliation first.

A dedicated finder `getOpenBankStatementLine()` is used instead of `getC_BankStatementLine_ID()` (which filters to `CO`/`CL` statements and joins the match table), so the guard targets only open reconciliations. Placing it in `reverseIt` covers both `reverseCorrectIt` and `reverseAccrualIt`. Payments already on a completed or closed bank statement keep their previous reversal behavior.

## Notes

Relies on the `Payment.ExistBankStatement` message being present in the application dictionary.
