### PR TITLE
Generate payroll incidences when a leave is completed

### DIFF
--- a/base/src/main/java/org/adempiere/core/domains/models/I_HR_AttendanceBatch.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/I_HR_AttendanceBatch.java
@@ -238,6 +238,19 @@ public interface I_HR_AttendanceBatch
 	  */
 	public boolean isActive();
 
+    /** Column name IsApprovalRequired */
+    public static final String COLUMNNAME_IsApprovalRequired = "IsApprovalRequired";
+
+	/** Set Approval Required.
+	  * Indicates whether this attendance batch requires approval
+	  */
+	public void setIsApprovalRequired (boolean IsApprovalRequired);
+
+	/** Get Approval Required.
+	  * Indicates whether this attendance batch requires approval
+	  */
+	public boolean isApprovalRequired();
+
     /** Column name IsApproved */
     public static final String COLUMNNAME_IsApproved = "IsApproved";
 

--- a/base/src/main/java/org/adempiere/core/domains/models/I_HR_Incidence.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/I_HR_Incidence.java
@@ -262,6 +262,17 @@ public interface I_HR_Incidence
 	/** Get Employee Incidence	  */
 	public int getHR_Incidence_ID();
 
+    /** Column name HR_Leave_ID */
+    public static final String COLUMNNAME_HR_Leave_ID = "HR_Leave_ID";
+
+	/** Set Employee Leave	  */
+	public void setHR_Leave_ID (int HR_Leave_ID);
+
+	/** Get Employee Leave	  */
+	public int getHR_Leave_ID();
+
+	public org.adempiere.core.domains.models.I_HR_Leave getHR_Leave() throws RuntimeException;
+
     /** Column name HR_ShiftIncidence_ID */
     public static final String COLUMNNAME_HR_ShiftIncidence_ID = "HR_ShiftIncidence_ID";
 

--- a/base/src/main/java/org/adempiere/core/domains/models/I_HR_LeaveReason.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/I_HR_LeaveReason.java
@@ -119,6 +119,15 @@ public interface I_HR_LeaveReason
 	  */
 	public boolean isActive();
 
+    /** Column name IsGeneratedFromAttendance */
+    public static final String COLUMNNAME_IsGeneratedFromAttendance = "IsGeneratedFromAttendance";
+
+	/** Set Generated From Attendance	  */
+	public void setIsGeneratedFromAttendance (boolean IsGeneratedFromAttendance);
+
+	/** Get Generated From Attendance	  */
+	public boolean isGeneratedFromAttendance();
+
     /** Column name LeaveReasonType */
     public static final String COLUMNNAME_LeaveReasonType = "LeaveReasonType";
 

--- a/base/src/main/java/org/adempiere/core/domains/models/I_HR_LeaveType.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/I_HR_LeaveType.java
@@ -51,19 +51,6 @@ public interface I_HR_LeaveType
 	  */
 	public int getAD_Client_ID();
 
-    /** Column name AD_Org_ID */
-    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
-
-	/** Set Organization.
-	  * Organizational entity within client
-	  */
-	public void setAD_Org_ID (int AD_Org_ID);
-
-	/** Get Organization.
-	  * Organizational entity within client
-	  */
-	public int getAD_Org_ID();
-
     /** Column name AdjacentHolidayType */
     public static final String COLUMNNAME_AdjacentHolidayType = "AdjacentHolidayType";
 
@@ -76,6 +63,19 @@ public interface I_HR_LeaveType
 	  * Adjacent Holidays Type
 	  */
 	public String getAdjacentHolidayType();
+
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within client
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within client
+	  */
+	public int getAD_Org_ID();
 
     /** Column name Created */
     public static final String COLUMNNAME_Created = "Created";
@@ -183,6 +183,15 @@ public interface I_HR_LeaveType
 	  * Allowed Encashment
 	  */
 	public boolean isAllowedEncashment();
+
+    /** Column name IsGeneratedFromAttendance */
+    public static final String COLUMNNAME_IsGeneratedFromAttendance = "IsGeneratedFromAttendance";
+
+	/** Set Generated From Attendance	  */
+	public void setIsGeneratedFromAttendance (boolean IsGeneratedFromAttendance);
+
+	/** Get Generated From Attendance	  */
+	public boolean isGeneratedFromAttendance();
 
     /** Column name IsHalfDayLeaveAllowed */
     public static final String COLUMNNAME_IsHalfDayLeaveAllowed = "IsHalfDayLeaveAllowed";

--- a/base/src/main/java/org/adempiere/core/domains/models/X_HR_AttendanceBatch.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/X_HR_AttendanceBatch.java
@@ -36,7 +36,7 @@ public class X_HR_AttendanceBatch extends PO implements I_HR_AttendanceBatch, I_
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20260806L;
+	private static final long serialVersionUID = 20260811L;
 
     /** Standard Constructor */
     public X_HR_AttendanceBatch (Properties ctx, int HR_AttendanceBatch_ID, String trxName)
@@ -395,6 +395,30 @@ public class X_HR_AttendanceBatch extends PO implements I_HR_AttendanceBatch, I_
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
+	}
+
+	/** Set Approval Required.
+		@param IsApprovalRequired 
+		Indicates whether this attendance batch requires approval
+	  */
+	public void setIsApprovalRequired (boolean IsApprovalRequired)
+	{
+		set_Value (COLUMNNAME_IsApprovalRequired, Boolean.valueOf(IsApprovalRequired));
+	}
+
+	/** Get Approval Required.
+		@return Indicates whether this attendance batch requires approval
+	  */
+	public boolean isApprovalRequired () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsApprovalRequired);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
 	}
 
 	/** Set Approved.

--- a/base/src/main/java/org/adempiere/core/domains/models/X_HR_Incidence.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/X_HR_Incidence.java
@@ -464,6 +464,31 @@ public class X_HR_Incidence extends PO implements I_HR_Incidence, I_Persistent
 		return ii.intValue();
 	}
 
+	public org.adempiere.core.domains.models.I_HR_Leave getHR_Leave() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_Leave)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_Leave.Table_Name)
+			.getPO(getHR_Leave_ID(), get_TrxName());	}
+
+	/** Set Employee Leave.
+		@param HR_Leave_ID Employee Leave	  */
+	public void setHR_Leave_ID (int HR_Leave_ID)
+	{
+		if (HR_Leave_ID < 1)
+			set_Value (COLUMNNAME_HR_Leave_ID, null);
+		else
+			set_Value (COLUMNNAME_HR_Leave_ID, Integer.valueOf(HR_Leave_ID));
+	}
+
+	/** Get Employee Leave.
+		@return Employee Leave	  */
+	public int getHR_Leave_ID ()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_Leave_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
 	public org.adempiere.core.domains.models.I_HR_ShiftIncidence getHR_ShiftIncidence() throws RuntimeException
     {
 		return (org.adempiere.core.domains.models.I_HR_ShiftIncidence)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_ShiftIncidence.Table_Name)

--- a/base/src/main/java/org/adempiere/core/domains/models/X_HR_LeaveReason.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/X_HR_LeaveReason.java
@@ -35,7 +35,7 @@ public class X_HR_LeaveReason extends PO implements I_HR_LeaveReason, I_Persiste
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20230102L;
+	private static final long serialVersionUID = 20260813L;
 
     /** Standard Constructor */
     public X_HR_LeaveReason (Properties ctx, int HR_LeaveReason_ID, String trxName)
@@ -115,6 +115,27 @@ public class X_HR_LeaveReason extends PO implements I_HR_LeaveReason, I_Persiste
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
+	}
+
+	/** Set Generated From Attendance.
+		@param IsGeneratedFromAttendance Generated From Attendance	  */
+	public void setIsGeneratedFromAttendance (boolean IsGeneratedFromAttendance)
+	{
+		set_Value (COLUMNNAME_IsGeneratedFromAttendance, Boolean.valueOf(IsGeneratedFromAttendance));
+	}
+
+	/** Get Generated From Attendance.
+		@return Generated From Attendance	  */
+	public boolean isGeneratedFromAttendance () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsGeneratedFromAttendance);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
 	}
 
 	/** LeaveReasonType AD_Reference_ID=53610 */

--- a/base/src/main/java/org/adempiere/core/domains/models/X_HR_LeaveType.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/X_HR_LeaveType.java
@@ -38,7 +38,7 @@ public class X_HR_LeaveType extends PO implements I_HR_LeaveType, I_Persistent
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20230102L;
+	private static final long serialVersionUID = 20260813L;
 
     /** Standard Constructor */
     public X_HR_LeaveType (Properties ctx, int HR_LeaveType_ID, String trxName)
@@ -246,6 +246,27 @@ public class X_HR_LeaveType extends PO implements I_HR_LeaveType, I_Persistent
 	public boolean isAllowedEncashment () 
 	{
 		Object oo = get_Value(COLUMNNAME_IsAllowedEncashment);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Generated From Attendance.
+		@param IsGeneratedFromAttendance Generated From Attendance	  */
+	public void setIsGeneratedFromAttendance (boolean IsGeneratedFromAttendance)
+	{
+		set_Value (COLUMNNAME_IsGeneratedFromAttendance, Boolean.valueOf(IsGeneratedFromAttendance));
+	}
+
+	/** Get Generated From Attendance.
+		@return Generated From Attendance	  */
+	public boolean isGeneratedFromAttendance () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsGeneratedFromAttendance);
 		if (oo != null) 
 		{
 			 if (oo instanceof Boolean) 

--- a/base/src/main/java/org/adempiere/core/domains/models/X_HR_ShiftIncidence.java
+++ b/base/src/main/java/org/adempiere/core/domains/models/X_HR_ShiftIncidence.java
@@ -190,6 +190,8 @@ public class X_HR_ShiftIncidence extends PO implements I_HR_ShiftIncidence, I_Pe
 	public static final String EVENTTYPE_Leave = "L";
 	/** Egress = O */
 	public static final String EVENTTYPE_Egress = "O";
+	/** Absence = X */
+	public static final String EVENTTYPE_Absence = "X";
 	/** Set Event Type.
 		@param EventType 
 		Type of Event

--- a/hr_and_payroll/src/main/java/org/eevolution/hr/model/MHRLeave.java
+++ b/hr_and_payroll/src/main/java/org/eevolution/hr/model/MHRLeave.java
@@ -16,13 +16,8 @@
  *****************************************************************************/
 package org.eevolution.hr.model;
 
-import java.io.File;
-import java.math.BigDecimal;
-import java.sql.ResultSet;
-import java.sql.Timestamp;
-import java.util.Properties;
-
 import org.adempiere.core.domains.models.X_HR_Leave;
+import org.adempiere.core.domains.models.X_HR_ShiftIncidence;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.*;
 import org.compiere.process.DocAction;
@@ -33,6 +28,16 @@ import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.compiere.util.TimeUtil;
 import org.spin.hr.util.TNAUtil;
+import org.spin.tar.model.MHRIncidence;
+import org.spin.tar.model.MHRShiftIncidence;
+import org.spin.tar.model.MHRShiftSchedule;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Properties;
 
 /** Generated Model for HR_Leave
  *  @author Adempiere (generated) 
@@ -47,13 +52,13 @@ public class MHRLeave extends X_HR_Leave implements DocAction, DocOptions {
 	public static final String		DocBaseType_Standard = "TNL";
 
     /** Standard Constructor */
-    public MHRLeave (Properties ctx, int HR_Leave_ID, String trxName)
+    public MHRLeave(Properties ctx, int HR_Leave_ID, String trxName)
     {
       super (ctx, HR_Leave_ID, trxName);
     }
 
     /** Load Constructor */
-    public MHRLeave (Properties ctx, ResultSet rs, String trxName)
+    public MHRLeave(Properties ctx, ResultSet rs, String trxName)
     {
       super (ctx, rs, trxName);
     }
@@ -292,8 +297,10 @@ public class MHRLeave extends X_HR_Leave implements DocAction, DocOptions {
 		if (!isApproved())
 			approveIt();
 		log.info(toString());
-		//	Reload Leave balance 
+		//	Reload Leave balance
 		addUsedLeave();
+		//	Generate incidences from the leave configuration (shift incidences of type Leave)
+		generateIncidences();
 		//	User Validation
 		String valid = ModelValidationEngine.get().fireDocValidate(this, ModelValidator.TIMING_AFTER_COMPLETE);
 		if (valid != null)
@@ -328,6 +335,126 @@ public class MHRLeave extends X_HR_Leave implements DocAction, DocOptions {
 			MHRLeaveAssign leaveAssign = new MHRLeaveAssign(getCtx(), getHR_LeaveAssign_ID(), get_TrxName());
 			leaveAssign.addUsedLeave(-1);
 			leaveAssign.saveEx();
+		}
+	}
+
+	/**
+	 * Generate the incidences for the leave.
+	 * The leave quantity is the whole leave duration, computed as the difference between
+	 * {@link #getStartDate()} and {@link #getEndDate()} (same criterion used for the leave duration),
+	 * and converted to the time unit configured on each shift incidence (typically hours). A single
+	 * incidence is created per shift incidence configured as
+	 * {@link X_HR_ShiftIncidence#EVENTTYPE_Leave Leave} on the work shift resolved for the leave start
+	 * day. Previously generated (non manual) incidences for the same leave are removed first, so the
+	 * method is safe to call again after a re-activation.
+	 */
+	private void generateIncidences() {
+		//	Remove previously generated (non manual) incidences for this leave
+		DB.executeUpdateEx("DELETE FROM HR_Incidence WHERE IsManual = 'N' AND HR_Leave_ID = " + getHR_Leave_ID(), get_TrxName());
+		//	Validate dates
+		Timestamp startDate = getStartDate();
+		Timestamp endDate = getEndDate();
+		if(startDate == null
+				|| endDate == null
+				|| !endDate.after(startDate)) {
+			return;
+		}
+		//	Resolve employee
+		MHREmployee employee = MHREmployee.getById(getCtx(), getHR_Employee_ID());
+		if(employee == null) {
+			return;
+		}
+		//	Resolve the work shift from the leave start day
+		Timestamp startDay = TimeUtil.getDay(startDate);
+		int workShiftId = getWorkShiftId(employee, startDay);
+		if(workShiftId <= 0) {
+			return;
+		}
+		//	Leave quantity = whole leave duration (End - Start); the unit comes from each shift incidence
+		long durationInMillis = TimeUtil.getMillisecondsBetween(startDate, endDate);
+		if(durationInMillis <= 0) {
+			return;
+		}
+		//	One incidence per shift incidence of type Leave applicable to the start day
+		List<MHRShiftIncidence> shiftIncidenceList = MHRShiftIncidence.getShiftIncidenceList(getCtx(), workShiftId, X_HR_ShiftIncidence.EVENTTYPE_Leave, startDay);
+		for(MHRShiftIncidence shiftIncidence : shiftIncidenceList) {
+			MHRIncidence incidence = new MHRIncidence(this, shiftIncidence, durationInMillis);
+			incidence.setServiceDate(startDay);
+			incidence.saveEx();
+		}
+		//	Complete when the organization is configured for it
+		completeIncidencesIfRequired();
+	}
+
+
+
+	/**
+	 * Resolve the work shift for the employee at a given date, using the same precedence as the
+	 * attendance import (ImportAttendance#getWorkShiftId): first the employee shift group, then the
+	 * work group (its direct shift regardless of the shift allocation flag, and as a last option the
+	 * default shift of its shift group). The rotating shift schedule of the work group is only used
+	 * as a final fallback, for configurations that actually rely on it. This keeps the leave
+	 * incidence generation consistent with how the attendance batch resolves the work shift, so it
+	 * no longer depends on the work group having IsShiftAllocation = Y or a shift schedule loaded.
+	 * @param employee
+	 * @param date used only for the shift schedule fallback
+	 * @return work shift id or 0 when it can not be resolved
+	 */
+	private int getWorkShiftId(MHREmployee employee, Timestamp date) {
+		int workShiftId = 0;
+		//	Employee shift group
+		if(employee.getHR_ShiftGroup_ID() > 0) {
+			MHRWorkShift workShift = MHRWorkShift.getDefaultFromGroup(getCtx(), employee.getHR_ShiftGroup_ID(), get_TrxName());
+			if(workShift != null) {
+				workShiftId = workShift.getHR_WorkShift_ID();
+			}
+		}
+		//	Work group: direct shift, then the default shift of its shift group
+		if(workShiftId <= 0
+				&& employee.getHR_WorkGroup_ID() > 0) {
+			MHRWorkGroup workGroup = MHRWorkGroup.getById(getCtx(), employee.getHR_WorkGroup_ID(), get_TrxName());
+			if(workGroup.getHR_WorkShift_ID() > 0) {
+				workShiftId = workGroup.getHR_WorkShift_ID();
+			}
+			if(workShiftId <= 0
+					&& workGroup.getHR_ShiftGroup_ID() > 0) {
+				MHRWorkShift workShift = MHRWorkShift.getDefaultFromGroup(getCtx(), workGroup.getHR_ShiftGroup_ID(), get_TrxName());
+				if(workShift != null) {
+					workShiftId = workShift.getHR_WorkShift_ID();
+				}
+			}
+			//	Last resort: rotating shift schedule of the work group
+			if(workShiftId <= 0) {
+				MHRShiftSchedule shiftSchedule = MHRShiftSchedule.getScheduleFromWorkGroup(getCtx(), workGroup.getHR_WorkGroup_ID(), date, get_TrxName());
+				if(shiftSchedule != null) {
+					workShiftId = shiftSchedule.getHR_WorkShift_ID();
+				}
+			}
+		}
+		return workShiftId;
+	}
+
+	/**
+	 * Complete the incidences generated for the leave when the organization is configured to
+	 * create them already completed (AD_OrgInfo.IsAutoCompleteIncidence = Y). Same behavior as
+	 * the attendance batch.
+	 */
+	private void completeIncidencesIfRequired() {
+		MOrgInfo orgInfo = MOrgInfo.get(getCtx(), getAD_Org_ID(), get_TrxName());
+		if(orgInfo == null
+				|| !"Y".equals(orgInfo.getIsAutoCompleteIncidence())) {
+			return;
+		}
+		int[] incidenceIds = new Query(getCtx(), MHRIncidence.Table_Name,
+				"HR_Leave_ID = ? AND IsManual = 'N' AND DocStatus = ?", get_TrxName())
+			.setParameters(getHR_Leave_ID(), DocAction.STATUS_Drafted)
+			.getIDs();
+		for(int incidenceId : incidenceIds) {
+			MHRIncidence incidence = new MHRIncidence(getCtx(), incidenceId, get_TrxName());
+			if(!incidence.processIt(DocAction.ACTION_Complete)) {
+				throw new AdempiereException("@ProcessRunError@ " + incidence.getProcessMsg());
+			}
+			incidence.saveEx();
 		}
 	}
 	
@@ -366,6 +493,8 @@ public class MHRLeave extends X_HR_Leave implements DocAction, DocOptions {
 			return false;
 		addDescription(Msg.getMsg(getCtx(), "Voided"));
 		removeUsedLeave();
+		//	Remove incidences generated for this leave
+		DB.executeUpdateEx("DELETE FROM HR_Incidence WHERE IsManual = 'N' AND HR_Leave_ID = " + getHR_Leave_ID(), get_TrxName());
 		// After Void
 		m_processMsg = ModelValidationEngine.get().fireDocValidate(this,ModelValidator.TIMING_AFTER_VOID);
 		if (m_processMsg != null)

--- a/hr_time_and_attendance/src/main/java/org/spin/tar/model/MHRAttendanceBatch.java
+++ b/hr_time_and_attendance/src/main/java/org/spin/tar/model/MHRAttendanceBatch.java
@@ -323,8 +323,8 @@ public class MHRAttendanceBatch extends X_HR_AttendanceBatch implements DocActio
 		scriptCtx.remove("_AttendanceDurationInMillis");
 		scriptCtx.remove("_AttendanceHours");
 		scriptCtx.remove("_AttendanceMinutes");
-		//	Get Worked time
-		List<MHRShiftIncidence> shiftIncidenceList = MHRShiftIncidence.getShiftIncidenceList(getCtx(), workShift.getHR_WorkShift_ID(), X_HR_ShiftIncidence.EVENTTYPE_Leave, getDateDoc());
+		//	Get Worked time (absence configuration from the work shift)
+		List<MHRShiftIncidence> shiftIncidenceList = MHRShiftIncidence.getShiftIncidenceList(getCtx(), workShift.getHR_WorkShift_ID(), X_HR_ShiftIncidence.EVENTTYPE_Absence, getDateDoc());
 		//	Get from work shift
 		BigDecimal noOfHours = workShift.getNoOfHours();
 		if(noOfHours == null) {

--- a/hr_time_and_attendance/src/main/java/org/spin/tar/model/MHRIncidence.java
+++ b/hr_time_and_attendance/src/main/java/org/spin/tar/model/MHRIncidence.java
@@ -35,6 +35,7 @@ import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.compiere.util.Util;
+import org.eevolution.hr.model.MHRLeave;
 
 /** Generated Model for HR_Incidence
  *  @author Adempiere (generated) 
@@ -136,6 +137,46 @@ public class MHRIncidence extends X_HR_Incidence implements DocAction, DocOption
     }
     
     
+    /**
+     * Create from Leave and Shift Incidence.
+     * Mirrors the millisecond based constructor used for attendance, but the reference
+     * document is the employee leave instead of the attendance batch, so the incidence
+     * is linked through HR_Leave_ID and has no attendance batch.
+     * @param leave
+     * @param shiftIncidence
+     * @param durationInMillis
+     */
+    public MHRIncidence(MHRLeave leave, MHRShiftIncidence shiftIncidence, long durationInMillis) {
+    	super(leave.getCtx(), 0, leave.get_TrxName());
+    	//	Set default values
+    	setHR_Leave_ID(leave.getHR_Leave_ID());
+    	setDateDoc(leave.getDateDoc());
+    	setServiceDate(leave.getStartDate());
+    	setC_BPartner_ID(leave.getC_BPartner_ID());
+    	setHR_Employee_ID(leave.getHR_Employee_ID());
+    	setHR_ShiftIncidence_ID(shiftIncidence.getHR_ShiftIncidence_ID());
+    	setHR_Concept_ID(shiftIncidence.getHR_Concept_ID());
+    	//	Validate time
+    	if(durationInMillis == 0
+    			|| Util.isEmpty(shiftIncidence.getTimeUnit())) {
+    		if(shiftIncidence.getFixedQty() != null
+    				&& !shiftIncidence.getFixedQty().equals(Env.ZERO)) {
+    			setQty(shiftIncidence.getFixedQty());
+    		}if(shiftIncidence.getFixedAmt() != null
+    				&& !shiftIncidence.getFixedAmt().equals(Env.ZERO)) {
+    			setAmt(shiftIncidence.getFixedAmt());
+    		}
+    	} else {
+    		//	Set Quantity
+    		double time = getTime(shiftIncidence.getTimeUnit(), durationInMillis);
+    		if(time == 0) {
+    			throw new AdempiereException("@TimeUnit@ @NotFound@");
+    		}
+    		//
+    		setQty(new BigDecimal(time));
+    	}
+    }
+
     /**
      * Get Time from duration and time unit
      * @param timeUnit

--- a/hr_time_and_attendance/src/main/java/org/spin/tar/model/MHRShiftIncidence.java
+++ b/hr_time_and_attendance/src/main/java/org/spin/tar/model/MHRShiftIncidence.java
@@ -195,6 +195,7 @@ public class MHRShiftIncidence extends X_HR_ShiftIncidence {
 		String egress = X_HR_ShiftIncidence.EVENTTYPE_Egress;
 		String attendance = X_HR_ShiftIncidence.EVENTTYPE_Attendance;
 		String leave = X_HR_ShiftIncidence.EVENTTYPE_Leave;
+		String absence = X_HR_ShiftIncidence.EVENTTYPE_Absence;
 		//	Load Hash
 		if(shiftIncidenceList != null) {
 			//	Sunday
@@ -202,36 +203,43 @@ public class MHRShiftIncidence extends X_HR_ShiftIncidence {
 			shiftIncidenceForDaysCache.put(keyPrefix + egress + Calendar.SUNDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + attendance + Calendar.SUNDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + leave + Calendar.SUNDAY, new ArrayList<MHRShiftIncidence>());
+			shiftIncidenceForDaysCache.put(keyPrefix + absence + Calendar.SUNDAY, new ArrayList<MHRShiftIncidence>());
 			//	Monday
 			shiftIncidenceForDaysCache.put(keyPrefix + entrance + Calendar.MONDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + egress + Calendar.MONDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + attendance + Calendar.MONDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + leave + Calendar.MONDAY, new ArrayList<MHRShiftIncidence>());
+			shiftIncidenceForDaysCache.put(keyPrefix + absence + Calendar.MONDAY, new ArrayList<MHRShiftIncidence>());
 			//	Tuesday
 			shiftIncidenceForDaysCache.put(keyPrefix + entrance + Calendar.TUESDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + egress + Calendar.TUESDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + attendance + Calendar.TUESDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + leave + Calendar.TUESDAY, new ArrayList<MHRShiftIncidence>());
+			shiftIncidenceForDaysCache.put(keyPrefix + absence + Calendar.TUESDAY, new ArrayList<MHRShiftIncidence>());
 			//	Wednesday
 			shiftIncidenceForDaysCache.put(keyPrefix + entrance + Calendar.WEDNESDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + egress + Calendar.WEDNESDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + attendance + Calendar.WEDNESDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + leave + Calendar.WEDNESDAY, new ArrayList<MHRShiftIncidence>());
+			shiftIncidenceForDaysCache.put(keyPrefix + absence + Calendar.WEDNESDAY, new ArrayList<MHRShiftIncidence>());
 			//	Thursday
 			shiftIncidenceForDaysCache.put(keyPrefix + entrance + Calendar.THURSDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + egress + Calendar.THURSDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + attendance + Calendar.THURSDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + leave + Calendar.THURSDAY, new ArrayList<MHRShiftIncidence>());
+			shiftIncidenceForDaysCache.put(keyPrefix + absence + Calendar.THURSDAY, new ArrayList<MHRShiftIncidence>());
 			//	Friday
 			shiftIncidenceForDaysCache.put(keyPrefix + entrance + Calendar.FRIDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + egress + Calendar.FRIDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + attendance + Calendar.FRIDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + leave + Calendar.FRIDAY, new ArrayList<MHRShiftIncidence>());
+			shiftIncidenceForDaysCache.put(keyPrefix + absence + Calendar.FRIDAY, new ArrayList<MHRShiftIncidence>());
 			//	Saturday
 			shiftIncidenceForDaysCache.put(keyPrefix + entrance + Calendar.SATURDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + egress + Calendar.SATURDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + attendance + Calendar.SATURDAY, new ArrayList<MHRShiftIncidence>());
 			shiftIncidenceForDaysCache.put(keyPrefix + leave + Calendar.SATURDAY, new ArrayList<MHRShiftIncidence>());
+			shiftIncidenceForDaysCache.put(keyPrefix + absence + Calendar.SATURDAY, new ArrayList<MHRShiftIncidence>());
 			//	Add
 			for(MHRShiftIncidence shiftIncidence : shiftIncidenceList) {
 				if(!shiftIncidence.isOnSunday()


### PR DESCRIPTION
Generate payroll incidences when an HR_Leave is completed, so a leave produces the same shift incidences of type Leave that the attendance flow already generates.

## What changes

- On complete, `MHRLeave` now creates one `HR_Incidence` per shift incidence configured as `EVENTTYPE = Leave` on the employee's resolved work shift for the leave start day. The incidence quantity is the whole leave duration (`EndDate - StartDate`), and the unit comes from each shift incidence.
- Work shift resolution follows the same precedence as the attendance import: employee shift group, then the work group (its direct shift regardless of the shift allocation flag, then its shift group's default shift), and the work group's rotating shift schedule only as a last resort. It no longer requires `IsShiftAllocation = Y` or a loaded shift schedule.
- Generated incidences are auto-completed when `AD_OrgInfo.IsAutoCompleteIncidence = Y`, matching the attendance batch behavior.
- Completion is idempotent: previously generated non-manual incidences for the leave are removed first, and they are also removed on void.

## Why

Leaves employees whose work shift comes from a shift group produced no payroll incidence on completion, because the previous resolution only used the work group's direct shift when `IsShiftAllocation = Y` and otherwise depended on a shift schedule that is frequently not configured.
