### PR TITLE
fix: Recompute QtyToDeliver from order line

### DIFF
--- a/resources/1.5.15/00504140_D_1_5_15_Fix_QtyToDeliver_OutboundOrderToShip_SB.xml
+++ b/resources/1.5.15/00504140_D_1_5_15_Fix_QtyToDeliver_OutboundOrderToShip_SB.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Fix_QtyToDeliver_OutboundOrderToShip_SB" ReleaseNo="1.5.15" SeqNo="504140">
+    <Comments>OutboundOrderToShipSB Qty to deliver column computed the order line's overall open balance instead of this outbound line's own committed quantity minus what has actually shipped for it, so a partial Outbound Order showed the full order balance instead of its own committed amount</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="50605" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="ol.QtyOrdered-ol.QtyDelivered">iobl.MovementQty - COALESCE((SELECT SUM(iol.MovementQty) FROM M_InOutLine iol INNER JOIN M_InOut io ON (io.M_InOut_ID = iol.M_InOut_ID) WHERE iol.WM_InOutBoundLine_ID = iobl.WM_InOutBoundLine_ID AND io.DocStatus IN ('CO','CL')), 0)</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/warehouse/src/main/java/org/eevolution/wms/model/MWMInOutBoundLine.java
+++ b/warehouse/src/main/java/org/eevolution/wms/model/MWMInOutBoundLine.java
@@ -265,6 +265,11 @@ public class MWMInOutBoundLine extends X_WM_InOutBoundLine
 	 * @return BigDecimal with Quantity to Ship
 	 */
 	public BigDecimal getQtyToDeliver() {
+		if (getWM_InOutBoundLine_ID() > 0) {
+			// Already-committed outbound line: return what of its own commitment is still unshipped,
+			// not the order line's overall open balance (which ignores other splits of the same order line).
+			return getMovementQty().subtract(getShipmentQtyDelivered());
+		}
 		if(getC_OrderLine_ID() > 0) {
 			Optional<I_C_OrderLine> maybeOrderLine = Optional.ofNullable(getOrderLine());
 			AtomicReference<BigDecimal> quantityToDeliver = new AtomicReference<>(BigDecimal.ZERO);

--- a/warehouse/src/main/java/org/eevolution/wms/process/GenerateShipmentOutBound.java
+++ b/warehouse/src/main/java/org/eevolution/wms/process/GenerateShipmentOutBound.java
@@ -60,7 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
@@ -353,7 +352,8 @@ public class GenerateShipmentOutBound extends GenerateShipmentOutBoundAbstract {
     }
 
     private BigDecimal getSalesOrderQtyToDelivery(MWMInOutBoundLine outboundLine) {
-        return Optional.ofNullable(getSelectionAsBigDecimal(outboundLine.getWM_InOutBoundLine_ID(), "QtyToDeliver")).orElse(outboundLine.getQtyToDeliver());
+        // Always recompute from the order line; never trust a client-supplied selection override, which can be stale.
+        return outboundLine.getQtyToDeliver();
     }
 
     private BigDecimal getManufacturingOrderQtyToDelivery(MWMInOutBoundLine outboundLine, MPPOrderBOMLine orderBOMLine) {


### PR DESCRIPTION
fix: Recompute QtyToDeliver from order line

## Summary
Generating a shipment from an outbound order line used a client-supplied quantity override instead of recalculating it, and the recalculation itself ignored how much of the order line's balance this specific outbound line actually committed when the order line was split across a partial Outbound Order — so an edited or partially-committed quantity was not reflected when generating the delivery, including in the OutboundOrderToShipSB smart browse used to launch that action.

## Changes
- `warehouse/src/main/java/org/eevolution/wms/process/GenerateShipmentOutBound.java` — `getSalesOrderQtyToDelivery` now always returns `outboundLine.getQtyToDeliver()` instead of preferring a row-selection override, matching the behavior already used by the Distribution Order and Manufacturing Order paths in the same class.
- `warehouse/src/main/java/org/eevolution/wms/model/MWMInOutBoundLine.java` — `getQtyToDeliver()` now returns the outbound line's own committed quantity (`MovementQty`) minus what has actually shipped for that specific line, once the line is persisted, instead of the order line's overall open balance. The not-yet-saved construction path keeps the previous order-line-based formula, since no own commitment exists yet at that point.
- `resources/1.5.15/00504140_D_1_5_15_Fix_QtyToDeliver_OutboundOrderToShip_SB.xml` — dictionary migration correcting the same bug in the `OutboundOrderToShipSB` smart browse's "Qty to deliver" column (AD_View_Column 50605), which computed `ol.QtyOrdered-ol.QtyDelivered` independently of the Java fix.

## Test plan
- [ ] Create/open a Sales Order line with an original quantity (e.g. 6), edit it (6 → 5), generate the Outbound Order and confirm "Qty to deliver" shows 5, not 6
- [ ] Create a Sales Order line with QtyOrdered=9, generate a partial Outbound Order committing only 7, and confirm "Qty to deliver" shows 7, not 9, both when generating the shipment and in the OutboundOrderToShipSB browse (after applying the migration)
- [ ] Generate the shipment and confirm the resulting `M_InOutLine.MovementQty` matches the outbound line's own committed/remaining quantity
- [ ] `./gradlew compileJava` succeeds