### PR TITLE
feat: CounterDoc only create if there is a valid configuration

### DIFF
--- a/base/src/main/java/org/compiere/model/MInOut.java
+++ b/base/src/main/java/org/compiere/model/MInOut.java
@@ -1993,21 +1993,16 @@ public class MInOut extends X_M_InOut implements DocAction , DocumentReversalEna
 
 		//	Document Type
 		int C_DocTypeTarget_ID = 0;
+		//	Require an explicit, valid counter document configuration.
+		//	Fail loudly instead so the missing C_DocTypeCounter mapping gets configured.
 		MDocTypeCounter counterDT = MDocTypeCounter.getCounterDocType(getCtx(), getC_DocType_ID());
-		if (counterDT != null)
-		{
-			log.fine(counterDT.toString());
-			if (!counterDT.isCreateCounter() || !counterDT.isValid())
-				return null;
-			C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
-		}
-		else	//	indirect
-		{
-			C_DocTypeTarget_ID = MDocTypeCounter.getCounterDocType_ID(getCtx(), getC_DocType_ID());
-			log.fine("Indirect C_DocTypeTarget_ID=" + C_DocTypeTarget_ID);
-			if (C_DocTypeTarget_ID <= 0)
-				return null;
-		}
+		if (counterDT == null)
+			throw new AdempiereException("@NotFound@ @C_DocTypeCounter_ID@ - @C_DocType_ID@="
+				+ MDocType.get(getCtx(), getC_DocType_ID()).getName());
+		log.fine(counterDT.toString());
+		if (!counterDT.isCreateCounter() || !counterDT.isValid())
+			return null;
+		C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
 
 		//	Deep Copy
 		MInOut counter = copyFrom(this, getMovementDate(), getDateAcct(),

--- a/base/src/main/java/org/compiere/model/MInvoice.java
+++ b/base/src/main/java/org/compiere/model/MInvoice.java
@@ -2539,21 +2539,16 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 
 		//	Document Type
 		int C_DocTypeTarget_ID = 0;
+		//	Require an explicit, valid counter document configuration.
+		//	Fail loudly instead so the missing C_DocTypeCounter mapping gets configured.
 		MDocTypeCounter counterDT = MDocTypeCounter.getCounterDocType(getCtx(), getC_DocType_ID());
-		if (counterDT != null)
-		{
-			log.fine(counterDT.toString());
-			if (!counterDT.isCreateCounter() || !counterDT.isValid())
-				return null;
-			C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
-		}
-		else	//	indirect
-		{
-			C_DocTypeTarget_ID = MDocTypeCounter.getCounterDocType_ID(getCtx(), getC_DocType_ID());
-			log.fine("Indirect C_DocTypeTarget_ID=" + C_DocTypeTarget_ID);
-			if (C_DocTypeTarget_ID <= 0)
-				return null;
-		}
+		if (counterDT == null)
+			throw new AdempiereException("@NotFound@ @C_DocTypeCounter_ID@ - @C_DocType_ID@="
+				+ MDocType.get(getCtx(), getC_DocType_ID()).getName());
+		log.fine(counterDT.toString());
+		if (!counterDT.isCreateCounter() || !counterDT.isValid())
+			return null;
+		C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
 
 		//	Deep Copy
 		MInvoice counter = copyFrom(this, getDateInvoiced(), getDateAcct(),

--- a/base/src/main/java/org/compiere/model/MOrder.java
+++ b/base/src/main/java/org/compiere/model/MOrder.java
@@ -567,6 +567,12 @@ public class MOrder extends X_C_Order implements DocAction
 
 			// don't copy linked lines
 			line.setLink_OrderLine_ID(0);
+			//	Do not propagate return references: Ref_InOutLine_ID / Ref_InvoiceLine_ID
+			//	are only meaningful on RMA create-from flows. PO.copyValues copies them, and
+			//	leaving them on a copied/counter order leaks the reference to non-return
+			//	orders, which breaks RV_OrderRMA_CreateFrom (C_Order_CreateFrom_InOut_RMA).
+			line.setRef_InOutLine_ID(0);
+			line.setRef_InvoiceLine_ID(0);
 			//	Tax
 			if (getC_BPartner_ID() != otherOrder.getC_BPartner_ID())
 				line.setTax();		//	recalculate
@@ -2352,23 +2358,18 @@ public class MOrder extends X_C_Order implements DocAction
 		MOrgInfo counterOrgInfo = MOrgInfo.get(getCtx(), counterAD_Org_ID, get_TrxName());
 		log.info("Counter BP=" + counterBP.getName());
 
-		//	Document Type
+		//	Document Type - require an explicit, valid counter document configuration.
+		// Fail loudly instead so the
+		//	missing C_DocTypeCounter mapping gets configured.
 		int C_DocTypeTarget_ID = 0;
 		MDocTypeCounter counterDT = MDocTypeCounter.getCounterDocType(getCtx(), getC_DocType_ID());
-		if (counterDT != null)
-		{
-			log.fine(counterDT.toString());
-			if (!counterDT.isCreateCounter() || !counterDT.isValid())
-				return null;
-			C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
-		}
-		else	//	indirect
-		{
-			C_DocTypeTarget_ID = MDocTypeCounter.getCounterDocType_ID(getCtx(), getC_DocType_ID());
-			log.fine("Indirect C_DocTypeTarget_ID=" + C_DocTypeTarget_ID);
-			if (C_DocTypeTarget_ID <= 0)
-				return null;
-		}
+		if (counterDT == null)
+			throw new AdempiereException("@NotFound@ @C_DocTypeCounter_ID@ - @C_DocType_ID@="
+				+ MDocType.get(getCtx(), getC_DocType_ID()).getName());
+		log.fine(counterDT.toString());
+		if (!counterDT.isCreateCounter() || !counterDT.isValid())
+			return null;
+		C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
 		//	Deep Copy
 		MOrder counter = copyFrom (this, getDateOrdered(), 
 			C_DocTypeTarget_ID, !isSOTrx(), true, false, get_TrxName());

--- a/base/src/main/java/org/compiere/model/MPayment.java
+++ b/base/src/main/java/org/compiere/model/MPayment.java
@@ -1860,21 +1860,16 @@ public final class MPayment extends X_C_Payment
 
 		//	Document Type
 		int C_DocTypeTarget_ID = 0;
+		//	Require an explicit, valid counter document configuration.
+		//	Fail loudly instead so the missing C_DocTypeCounter mapping gets configured.
 		MDocTypeCounter counterDT = MDocTypeCounter.getCounterDocType(getCtx(), getC_DocType_ID());
-		if (counterDT != null)
-		{
-			log.fine(counterDT.toString());
-			if (!counterDT.isCreateCounter() || !counterDT.isValid())
-				return null;
-			C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
-		}
-		else	//	indirect
-		{
-			C_DocTypeTarget_ID = MDocTypeCounter.getCounterDocType_ID(getCtx(), getC_DocType_ID());
-			log.fine("Indirect C_DocTypeTarget_ID=" + C_DocTypeTarget_ID);
-			if (C_DocTypeTarget_ID <= 0)
-				return null;
-		}
+		if (counterDT == null)
+			throw new AdempiereException("@NotFound@ @C_DocTypeCounter_ID@ - @C_DocType_ID@="
+				+ MDocType.get(getCtx(), getC_DocType_ID()).getName());
+		log.fine(counterDT.toString());
+		if (!counterDT.isCreateCounter() || !counterDT.isValid())
+			return null;
+		C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
 
 		//	Deep Copy
 		MPayment counter = new MPayment (getCtx(), 0, get_TrxName());

--- a/base/src/main/java/org/compiere/model/MRMA.java
+++ b/base/src/main/java/org/compiere/model/MRMA.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.logging.Level;
 
 import org.adempiere.core.domains.models.I_M_InOut;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.core.domains.models.I_M_RMALine;
 import org.adempiere.core.domains.models.X_M_RMA;
 import org.compiere.process.DocAction;
@@ -494,21 +495,16 @@ public class MRMA extends X_M_RMA implements DocAction
 
 		//	Document Type
 		int C_DocTypeTarget_ID = 0;
+		//	Require an explicit, valid counter document configuration.
+		//	Fail loudly instead so the missing C_DocTypeCounter mapping gets configured.
 		MDocTypeCounter counterDT = MDocTypeCounter.getCounterDocType(getCtx(), getC_DocType_ID());
-		if (counterDT != null)
-		{
-			log.fine(counterDT.toString());
-			if (!counterDT.isCreateCounter() || !counterDT.isValid())
-				return null;
-			C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
-		}
-		else	//	indirect
-		{
-			C_DocTypeTarget_ID = MDocTypeCounter.getCounterDocType_ID(getCtx(), getC_DocType_ID());
-			log.fine("Indirect C_DocTypeTarget_ID=" + C_DocTypeTarget_ID);
-			if (C_DocTypeTarget_ID <= 0)
-				return null;
-		}
+		if (counterDT == null)
+			throw new AdempiereException("@NotFound@ @C_DocTypeCounter_ID@ - @C_DocType_ID@="
+				+ MDocType.get(getCtx(), getC_DocType_ID()).getName());
+		log.fine(counterDT.toString());
+		if (!counterDT.isCreateCounter() || !counterDT.isValid())
+			return null;
+		C_DocTypeTarget_ID = counterDT.getCounter_C_DocType_ID();
 
 		//	Deep Copy
 		MRMA counter = copyFrom(this, C_DocTypeTarget_ID, !isSOTrx(), true, get_TrxName());


### PR DESCRIPTION
Remove indirect counter doc creation by using defaults Throws error if document should create counter doc but there is no valid configuration.

In Order also clean Ref_InOutLine_ID reference so return order counter docs do not block original InOut