### PR TITLE
fix: Respect selected partial qty in outbound shipment

### DIFF
--- a/warehouse/src/main/java/org/eevolution/wms/process/GenerateShipmentOutBound.java
+++ b/warehouse/src/main/java/org/eevolution/wms/process/GenerateShipmentOutBound.java
@@ -353,8 +353,35 @@ public class GenerateShipmentOutBound extends GenerateShipmentOutBoundAbstract {
     }
 
     private BigDecimal getSalesOrderQtyToDelivery(MWMInOutBoundLine outboundLine) {
-        // Always recompute from the order line; never trust a client-supplied selection override, which can be stale.
-        return outboundLine.getQtyToDeliver();
+		// Outbound Order remnant: total committed on this outbound line minus what has
+		// already been shipped from it. This is the hard ceiling and already reflects
+		// edits made to the outbound line's own quantity (MovementQty).
+		BigDecimal outboundOrderQtyToDeliver = outboundLine.getQtyToDeliver();
+
+		if (isIncludeNotAvailable()) {
+			return outboundLine.getQtyToPick();
+		}
+
+		// Quantity the user edited/selected in the "Cantidad a Entregar" column of the
+		// Smart Browser (T_Selection). Null when the browser sent no override for this
+		// row (e.g. process invoked directly by Record_ID, bypassing the browser).
+		BigDecimal selectedQtyToDeliver = getSelectionAsBigDecimal(outboundLine.getWM_InOutBoundLine_ID(), "QtyToDeliver");
+
+		if (selectedQtyToDeliver == null) {
+			// No override sent at all: keep current full-remnant behavior (non-browser path).
+			return outboundOrderQtyToDeliver;
+		}
+
+		if (selectedQtyToDeliver.signum() <= 0) {
+			throw new AdempiereException("@QtyMustBeGreaterThanZero@ (WM_InOutBoundLine_ID=" + outboundLine.getWM_InOutBoundLine_ID() + ")");
+		}
+
+		if (selectedQtyToDeliver.compareTo(outboundOrderQtyToDeliver) > 0) {
+			throw new AdempiereException("@QtyInsufficient@ @WM_InOutBoundLine_ID@=" + outboundLine.getWM_InOutBoundLine_ID()
+					+ ": @Qty@=" + selectedQtyToDeliver + ", @AvailableQty@=" + outboundOrderQtyToDeliver);
+		}
+
+		return selectedQtyToDeliver;
     }
 
     private BigDecimal getManufacturingOrderQtyToDelivery(MWMInOutBoundLine outboundLine, MPPOrderBOMLine orderBOMLine) {


### PR DESCRIPTION
## Summary
- Generating shipments from an Outbound Order ignored the partial quantity the user selected/edited in the "Cantidad a Entregar" column of the Smart Browser, always shipping the outbound line's full remaining commitment instead.

## Changes
- `warehouse/src/main/java/org/eevolution/wms/process/GenerateShipmentOutBound.java` — `getSalesOrderQtyToDelivery` now reads the user-selected quantity via `getSelectionAsBigDecimal(...)` and uses it when valid, capping it against the outbound line's own remaining commitment (`MovementQty - ShipmentQtyDelivered`). Falls back to the full remnant only when the browser sends no override. Throws `AdempiereException` when the selected quantity is zero/negative, or when it exceeds what's actually available — no silent clamping or over-delivery.

## Additional context
https://github.com/solop-develop/adempiere-base/pull/654

## Test plan
- [ ] Generate a full Outbound Order shipment without editing "Cantidad a Entregar" — delivers 100% (no regression)
- [ ] Outbound Order qty 10: partial shipment of 4, then partial of 3, then remaining 3 — each shipment matches the selected qty, remnant updates correctly after each
- [ ] Outbound Order qty 8: select 6 for first shipment — shipment has MovementQty=6 (not 8); reopen browser, remnant shows 2 (not 0.00); second shipment of 2 completes the order; sales order line QtyDelivered totals 8
- [ ] Select a quantity greater than the remaining balance — process throws an error, no shipment generated, remnant unchanged
- [ ] Select 0 or a negative quantity — process throws an error, no empty/negative shipment generated
- [ ] Repeat with `IsIncludeNotAvailable` enabled — behavior unaffected (still uses `QtyToPick`)
- [x] `./gradlew compileJava` succeeds


